### PR TITLE
Configured cache implementation for cache annotations

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
+++ b/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
@@ -46,13 +46,12 @@ public class AerospikeCache implements Cache {
 
 	@Override
 	public void clear() {
-		// TODO Auto-generated method stub
+		client.truncate(null, namespace, set, null);
 	}
 
 	@Override
 	public void evict(Object key) {
 		this.client.delete(null, getKey(key));
-
 	}
 
 	@Override
@@ -91,8 +90,7 @@ public class AerospikeCache implements Cache {
 
 	@Override
 	public <T> T get(Object key, Callable<T> valueLoader) {
-		// TODO Auto-generated method stub
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 

--- a/src/main/java/org/springframework/data/aerospike/cache/AerospikeCacheManager.java
+++ b/src/main/java/org/springframework/data/aerospike/cache/AerospikeCacheManager.java
@@ -46,11 +46,11 @@ import java.util.*;
  */
 public class AerospikeCacheManager extends AbstractTransactionSupportingCacheManager {
 
-	protected static final String DEFAULT_SET_NAME = "aerospike";
+	protected static final String DEFAULT_NAMESPACE = "test";
 
 	private final AerospikeClient aerospikeClient;
 	private final AerospikeConverter aerospikeConverter;
-	private final String setName;
+	private final String namespace;
 	private final Set<String> configuredCacheNames;
 
 	/**
@@ -69,11 +69,11 @@ public class AerospikeCacheManager extends AbstractTransactionSupportingCacheMan
 	 * specified set name.
 	 * 
 	 * @param aerospikeClient the {@link AerospikeClient} instance.
-	 * @param setName the set name.
+	 * @param namespace the set name.
 	 * @param aerospikeConverter
 	 */
-	public AerospikeCacheManager(AerospikeClient aerospikeClient, String setName, MappingAerospikeConverter aerospikeConverter) {
-		this(aerospikeClient, Collections.<String>emptyList(), setName, aerospikeConverter);
+	public AerospikeCacheManager(AerospikeClient aerospikeClient, String namespace, MappingAerospikeConverter aerospikeConverter) {
+		this(aerospikeClient, Collections.<String>emptyList(), namespace, aerospikeConverter);
 	}
 
 	/**
@@ -86,7 +86,7 @@ public class AerospikeCacheManager extends AbstractTransactionSupportingCacheMan
 	 */
 	public AerospikeCacheManager(AerospikeClient aerospikeClient,
 								 Collection<String> cacheNames, MappingAerospikeConverter aerospikeConverter) {
-		this(aerospikeClient, cacheNames, DEFAULT_SET_NAME, aerospikeConverter);
+		this(aerospikeClient, cacheNames, DEFAULT_NAMESPACE, aerospikeConverter);
 	}
 
 	/**
@@ -95,17 +95,17 @@ public class AerospikeCacheManager extends AbstractTransactionSupportingCacheMan
 	 * 
 	 * @param aerospikeClient the {@link AerospikeClient} instance.
 	 * @param cacheNames the default caches to create.
-	 * @param setName the set name.
+	 * @param namespace the namespace.
 	 * @param aerospikeConverter
 	 */
 	public AerospikeCacheManager(AerospikeClient aerospikeClient,
-								 Collection<String> cacheNames, String setName, MappingAerospikeConverter aerospikeConverter) {
+								 Collection<String> cacheNames, String namespace, MappingAerospikeConverter aerospikeConverter) {
 		Assert.notNull(aerospikeClient, "AerospikeClient must not be null");
 		Assert.notNull(cacheNames, "Cache names must not be null");
-		Assert.notNull(setName, "Set name must not be null");
+		Assert.notNull(namespace, "Namespace must not be null");
 		this.aerospikeClient = aerospikeClient;
 		this.aerospikeConverter = aerospikeConverter;
-		this.setName = setName;
+		this.namespace = namespace;
 		this.configuredCacheNames = new LinkedHashSet<String>(cacheNames);
 	}
 
@@ -143,8 +143,8 @@ public class AerospikeCacheManager extends AbstractTransactionSupportingCacheMan
 		}
 	}
 
-	protected Cache lookupAerospikeCache(String name) {
-		return lookupCache(name + ":" + setName);
+	protected Cache lookupAerospikeCache(String setName) {
+		return lookupCache(namespace + ":" + setName);
 	}
 
 	@Override
@@ -161,8 +161,8 @@ public class AerospikeCacheManager extends AbstractTransactionSupportingCacheMan
 
 	public class AerospikeSerializingCache extends AerospikeCache {
 
-		public AerospikeSerializingCache(String namespace) {
-			super(namespace, setName, aerospikeClient, -1);
+		public AerospikeSerializingCache(String setname) {
+			super(AerospikeCacheManager.this.namespace, setname, aerospikeClient, -1);
 		}
 
 		@Override

--- a/src/test/java/org/springframework/data/aerospike/cache/AerospikeCacheManagerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/aerospike/cache/AerospikeCacheManagerIntegrationTests.java
@@ -16,6 +16,7 @@ public class AerospikeCacheManagerIntegrationTests extends BaseIntegrationTests 
 
     private static final String KEY = "foo";
     private static final String VALUE = "bar";
+    private static final String SETNAME = "test";
 
     @Autowired
     AerospikeClient client;
@@ -25,7 +26,7 @@ public class AerospikeCacheManagerIntegrationTests extends BaseIntegrationTests 
     @After
     public void tearDown() throws Exception {
         cachingComponent.reset();
-        client.delete(null, new Key(getNameSpace(), AerospikeCacheManager.DEFAULT_SET_NAME, KEY));
+        client.delete(null, new Key(getNameSpace(), SETNAME, KEY));
     }
 
     @Test
@@ -59,13 +60,13 @@ public class AerospikeCacheManagerIntegrationTests extends BaseIntegrationTests 
             noOfCalls = 0;
         }
 
-        @Cacheable("TEST")
+        @Cacheable(SETNAME)
         public CachedObject cachingMethod(String param) {
             noOfCalls++;
             return new CachedObject(VALUE);
         }
 
-        @CacheEvict("TEST")
+        @CacheEvict(SETNAME)
         public void cacheEvictingMethod(String param) {
 
         }


### PR DESCRIPTION
Now cache annotation "value" attribute can be mapped with setname. Previously the value attribute of @Cachable was mapped with namespace. So now one can have multiple setname as seperate caches.