### PR TITLE
Use exists operation before touching

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -381,11 +381,6 @@ public class AerospikeTemplate implements AerospikeOperations {
 			return mapToEntity(key, type, record);
 		}
 		catch (AerospikeException e) {
-			//touch operation returns error if key not found
-			if (e.getResultCode() == ResultCode.KEY_NOT_FOUND_ERROR) {
-				return null;
-			}
-
 			DataAccessException translatedException = exceptionTranslator.translateExceptionIfPossible(e);
 			throw translatedException == null ? e : translatedException;
 		}
@@ -395,7 +390,10 @@ public class AerospikeTemplate implements AerospikeOperations {
 		WritePolicy writePolicy = new WritePolicy(client.writePolicyDefault);
 		writePolicy.expiration = expiration;
 
-		return this.client.operate(writePolicy, key, Operation.touch(), Operation.get());
+		if (this.client.exists(null, key)) {
+			return this.client.operate(writePolicy, key, Operation.touch(), Operation.get());
+		}
+		return null;
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeExpirationTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeExpirationTests.java
@@ -124,13 +124,14 @@ public class AerospikeExpirationTests extends BaseIntegrationTests {
         Key key = new Key(template.getNamespace(), template.getSetName(DocumentWithExpirationOneDay.class), id);
 
         Record record = template.getAerospikeClient().get(null, key);
-        assertThat(record.getTimeToLive()).isCloseTo((int) TimeUnit.DAYS.toSeconds(1), offset(30));
+        int initialExpiration = record.expiration;
 
-        Thread.sleep(1000);
+        Thread.sleep(2_000);
         template.findById(id, DocumentWithExpirationOneDay.class);
 
         record = template.getAerospikeClient().get(null, key);
-        assertThat(record.getTimeToLive()).isCloseTo((int) TimeUnit.DAYS.toSeconds(1), offset(30));
+        assertThat(record.expiration - initialExpiration)
+                .isCloseTo(2, offset(1));
     }
 
     @Test


### PR DESCRIPTION
Touch operation for non existing record increments client_write_error metric on server. Adding exists operation fixes that
See this topic:
https://discuss.aerospike.com/t/understanding-client-write-errors/4442
for more details