### PR TITLE
FindByIds operation should not return nulls

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeOperations.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeOperations.java
@@ -96,7 +96,14 @@ public interface AerospikeOperations {//extends KeyValueOperations {
 	<T> List<T> findAll(Class<T> type);
 
 	<T> T findById(Serializable id, Class<T> type);
-	<T> List<T> findByIDs(Iterable<Serializable> IDs, Class<T> type);
+
+	/**
+	 * Instead use findByIds
+	 */
+	@Deprecated
+	<T> List<T> findByIDs(Iterable<? extends Serializable> IDs, Class<T> type);
+
+	<T> List<T> findByIds(Iterable<?> IDs, Class<T> type);
 
 	<T> T add(T objectToAddTo, Map<String, Long> values);
 	<T> T add(T objectToAddTo, String binName, long value);

--- a/src/main/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepository.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepository.java
@@ -107,7 +107,7 @@ public class SimpleAerospikeRepository<T, ID extends Serializable> implements Ae
 	@SuppressWarnings("unchecked")
 	@Override
 	public Iterable<T> findAll(Iterable<ID> ids) {
-		return operations.findByIDs((Iterable<Serializable>)ids, entityInformation.getJavaType());
+		return operations.findByIds(ids, entityInformation.getJavaType());
 	}
 
 	/* (non-Javadoc)

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateTests.java
@@ -623,6 +623,49 @@ public class AerospikeTemplateTests extends BaseIntegrationTests {
 		assertThat(template.delete(one)).isFalse();
 	}
 
+	@Test
+	public void findByIds_shouldFindExisting() {
+		Person firstPerson = Person.builder().id(nextId()).firstName("first").emailAddress("gmail.com").build();
+		Person secondPerson = Person.builder().id(nextId()).firstName("second").emailAddress("gmail.com").build();
+		template.save(firstPerson);
+
+		template.save(secondPerson);
+
+		List<String> ids = Arrays.asList(nextId(), firstPerson.getId(), secondPerson.getId());
+
+		List<Person> actual = template.findByIds(ids, Person.class);
+
+		assertThat(actual).containsExactly(firstPerson, secondPerson);
+	}
+
+
+	@Test
+	public void findByIds_shouldReturnEmptyList() {
+		List<Person> actual = template.findByIds(Collections.emptyList(), Person.class);
+		assertThat(actual).isEmpty();
+	}
+
+	@Test
+	public void findByIds_deprecated_shouldFindExisting() {
+		Person firstPerson = Person.builder().id(nextId()).firstName("first").emailAddress("gmail.com").build();
+		Person secondPerson = Person.builder().id(nextId()).firstName("second").emailAddress("gmail.com").build();
+		template.save(firstPerson);
+
+		template.save(secondPerson);
+
+		Iterable<String> ids = Arrays.asList(nextId(), firstPerson.getId(), secondPerson.getId());
+
+		List<Person> actual = template.findByIDs(ids, Person.class);
+
+		assertThat(actual).containsExactly(firstPerson, secondPerson);
+	}
+
+	@Test
+	public void findByIds_deprecated_shouldReturnEmptyList() {
+		List<Person> actual = template.findByIDs(Collections.emptyList(), Person.class);
+		assertThat(actual).isEmpty();
+	}
+
 	@Test(expected = IllegalStateException.class)
 	public void findById_shouldFailOnTouchOnReadWithExpirationProperty() {
 		String id = nextId();


### PR DESCRIPTION
- Deprecated FindByIDs method and added FindByIds in AerospikeTemplate
- FindByIds operation should not return nulls