### PR TITLE
Not able to delete bins for documents without Version field

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -204,7 +204,7 @@ public class AerospikeTemplate implements AerospikeOperations {
 		} else {
 			WritePolicyBuilder builder = WritePolicyBuilder.builder(this.client.writePolicyDefault)
 					.sendKey(true)
-					.recordExistsAction(RecordExistsAction.UPDATE);
+					.recordExistsAction(RecordExistsAction.REPLACE);
 			doPersist(document, builder);
 		}
 	}


### PR DESCRIPTION
To remove fields from document we need to use REPLACE strategy instead of UPDATE.
According to aerospike-client documentation for REPLACE strategy:
Create or replace record.
Delete existing bins not referenced by write command bins.