### PR TITLE
spring-data-aerospike should not convert unrecognizable exceptions

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/core/DefaultAerospikeExceptionTranslator.java
+++ b/src/main/java/org/springframework/data/aerospike/core/DefaultAerospikeExceptionTranslator.java
@@ -61,6 +61,7 @@ public class DefaultAerospikeExceptionTranslator implements AerospikeExceptionTr
 
 			}
 		}
-		return new UncategorizedKeyValueException("Unexpected Aerospike Exception", cause);
+		//we should not convert exceptions that spring-data-aeropike does not recognise
+		return null;
 	}
 }

--- a/src/test/java/org/springframework/data/aerospike/core/DefaultAerospikeExceptionTranslatorTest.java
+++ b/src/test/java/org/springframework/data/aerospike/core/DefaultAerospikeExceptionTranslatorTest.java
@@ -84,9 +84,9 @@ public class DefaultAerospikeExceptionTranslatorTest {
     }
 
     @Test
-    public void shouldTranslateUnknownError() {
+    public void shouldNotTranslateUnknownError() {
         RuntimeException cause = new RuntimeException();
         DataAccessException actual = translator.translateExceptionIfPossible(cause);
-        assertThat(actual).isExactlyInstanceOf(UncategorizedKeyValueException.class);
+        assertThat(actual).isNull();
     }
 }


### PR DESCRIPTION
If multiple spring-data modules are used in project, spring-data-aerospike converts other's module exceptions, but should not.
According to documentation of `PersistenceExceptionTranslator`:
```
* <p>Do not translate exceptions that are not understood by this translator:
* for example, if coming from another persistence framework, or resulting
* from user code or otherwise unrelated to persistence.
 * @return the corresponding DataAccessException (or {@code null} if the
* exception could not be translated, as in this case it may result from
* user code rather than from an actual persistence problem)
``` 