### PR TITLE
Update production and test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,24 +16,24 @@
  	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>2.1.2.RELEASE</version>
+		<version>2.1.6.RELEASE</version>
 	</parent>
 
     <properties>
         <bundlor.enabled>false</bundlor.enabled>
         <source.level>1.8</source.level>
-        <aerospike>4.3.1</aerospike>
+        <aerospike>4.4.0</aerospike>
 
-        <springdata.commons>2.1.2.RELEASE</springdata.commons>
-        <springdata.keyvalue>2.1.2.RELEASE</springdata.keyvalue>
+        <springdata.commons>2.1.6.RELEASE</springdata.commons>
+        <springdata.keyvalue>2.1.6.RELEASE</springdata.keyvalue>
         <dist.key>DATAAERO</dist.key>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot-starter-test.version>2.0.3.RELEASE</spring-boot-starter-test.version>
-        <spring-cloud-starter.version>2.0.0.RELEASE</spring-cloud-starter.version>
-        <joda-time.version>2.9.9</joda-time.version>
-        <embedded-aerospike.version>1.13</embedded-aerospike.version>
-        <awaitility.version>3.1.1</awaitility.version>
+        <spring-boot-starter-test.version>2.1.4.RELEASE</spring-boot-starter-test.version>
+        <spring-cloud-starter.version>2.1.1.RELEASE</spring-cloud-starter.version>
+        <joda-time.version>2.10.1</joda-time.version>
+        <embedded-aerospike.version>1.19</embedded-aerospike.version>
+        <awaitility.version>3.1.6</awaitility.version>
     </properties>
 
     <licenses>
@@ -117,7 +117,6 @@
                 <artifactId>spring-data-commons</artifactId>
                 <version>${springdata.commons}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.springframework.data</groupId>
                 <artifactId>spring-data-keyvalue</artifactId>

--- a/src/main/java/org/springframework/data/aerospike/config/ReadPolicyFactoryBean.java
+++ b/src/main/java/org/springframework/data/aerospike/config/ReadPolicyFactoryBean.java
@@ -17,7 +17,6 @@ package org.springframework.data.aerospike.config;
 
 import org.springframework.beans.factory.FactoryBean;
 
-import com.aerospike.client.policy.ConsistencyLevel;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.Priority;
 
@@ -70,15 +69,6 @@ public class ReadPolicyFactoryBean implements FactoryBean<Policy> {
 	 */
 	public void setSleepBetweenRetries(int sleepBetweenRetries){
 		this.policy.sleepBetweenRetries = sleepBetweenRetries;
-	}
-
-	/**
-	 * Configures how replicas should be consulted in a read operation to provide the desired
-	 * consistency guarantee. Default to allowing one replica to be used in the
-	 * read operation.
-	 */
-	public void setConsistencyLevel(ConsistencyLevel consistencyLevel){
-		this.policy.consistencyLevel = consistencyLevel;
 	}
 
 	/**


### PR DESCRIPTION
Update production dependencies:
- aerospike-client 4.3.1 -> 4.4.0
- spring-data-parent 2.1.2.RELEASE -> 2.1.6.RELEASE
- spring-data-commons 2.1.2.RELEASE -> 2.1.6.RELEASE
- spring-data-keyvalue 2.1.2.RELEASE -> 2.1.6.RELEASE
- joda-time 2.9.9 -> 2.10.1

Update test dependencies:
- spring-boot-starter 2.0.3.RELEASE -> 2.1.4.RELEASE
- spring-cloud-starter 2.0.0.RELEASE -> 2.1.1.RELEASE
- embedded-aerospike 1.13 -> 1.19
- awaitility 3.1.1 -> 3.1.6