### PR TITLE
FMWK-285 Compare versions when performing delete operations

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeOperations.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeOperations.java
@@ -24,6 +24,7 @@ import com.aerospike.client.query.Filter;
 import com.aerospike.client.query.IndexCollectionType;
 import com.aerospike.client.query.IndexType;
 import com.aerospike.client.query.ResultSet;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.aerospike.config.AerospikeDataSettings;
 import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
@@ -105,6 +106,8 @@ public interface AerospikeOperations {
      * @param document The document to be saved. Must not be {@literal null}.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> void save(T document);
 
@@ -128,6 +131,8 @@ public interface AerospikeOperations {
      * @param setName  Set name to override the set associated with the document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> void save(T document, String setName);
 
@@ -139,12 +144,11 @@ public interface AerospikeOperations {
      * This operation requires Server version 6.0+.
      *
      * @param documents The documents to be saved. Must not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch save succeeds, but results contain errors or null records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void saveAll(Iterable<T> documents);
 
@@ -158,12 +162,11 @@ public interface AerospikeOperations {
      *
      * @param documents The documents to be saved. Must not be {@literal null}.
      * @param setName   Set name to override the default set associated with the documents.
-     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch save succeeds, but results contain errors or null records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void saveAll(Iterable<T> documents, String setName);
 
@@ -175,6 +178,8 @@ public interface AerospikeOperations {
      * @param document The document to be inserted. Must not be {@literal null}.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if batch operation failed (see
+     *                                           {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void insert(T document);
 
@@ -188,6 +193,8 @@ public interface AerospikeOperations {
      * @param setName  Set name to override the set associated with the document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if batch operation failed (see
+     *                                           {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void insert(T document, String setName);
 
@@ -199,12 +206,12 @@ public interface AerospikeOperations {
      * This operation requires Server version 6.0+.
      *
      * @param documents Documents to be inserted. Must not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch insert succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch insert succeeds, but results contain errors or null
+     *                                             records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void insertAll(Iterable<? extends T> documents);
 
@@ -218,12 +225,12 @@ public interface AerospikeOperations {
      *
      * @param documents Documents to be inserted. Must not be {@literal null}.
      * @param setName   Set name to override the set associated with the document.
-     * @throws AerospikeException.BatchRecordArray         if batch insert succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch insert succeeds, but results contain errors or null
+     *                                             records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void insertAll(Iterable<? extends T> documents, String setName);
 
@@ -233,6 +240,7 @@ public interface AerospikeOperations {
      * @param document    The document to be persisted. Must not be {@literal null}.
      * @param writePolicy The Aerospike write policy for the inner Aerospike put operation. Must not be
      *                    {@literal null}.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void persist(T document, WritePolicy writePolicy);
 
@@ -244,6 +252,7 @@ public interface AerospikeOperations {
      * @param writePolicy The Aerospike write policy for the inner Aerospike put operation. Must not be
      *                    {@literal null}.
      * @param setName     Set name to override the set associated with the document.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void persist(T document, WritePolicy writePolicy, String setName);
 
@@ -257,6 +266,8 @@ public interface AerospikeOperations {
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> void update(T document);
 
@@ -272,6 +283,8 @@ public interface AerospikeOperations {
      * @param setName  Set name to override the set associated with the document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> void update(T document, String setName);
 
@@ -287,6 +300,8 @@ public interface AerospikeOperations {
      * @param fields   Specific fields to update.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> void update(T document, Collection<String> fields);
 
@@ -303,6 +318,8 @@ public interface AerospikeOperations {
      * @param fields   Specific fields to update.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> void update(T document, String setName, Collection<String> fields);
 
@@ -314,12 +331,12 @@ public interface AerospikeOperations {
      * This operation requires Server version 6.0+.
      *
      * @param documents The documents that identify the records to be updated. Must not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch update succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch update succeeds, but results contain errors or null
+     *                                             records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void updateAll(Iterable<T> documents);
 
@@ -333,12 +350,12 @@ public interface AerospikeOperations {
      *
      * @param documents The documents that identify the records to be updated. Must not be {@literal null}.
      * @param setName   Set name to override the set associated with the document.
-     * @throws AerospikeException.BatchRecordArray         if batch update succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch update succeeds, but results contain errors or null
+     *                                             records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void updateAll(Iterable<T> documents, String setName);
 
@@ -369,6 +386,8 @@ public interface AerospikeOperations {
      * @return Whether the record existed on server before deletion.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> boolean delete(T document);
 
@@ -382,6 +401,8 @@ public interface AerospikeOperations {
      * @return Whether the record existed on server before deletion.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> boolean delete(T document, String setName);
 
@@ -394,12 +415,11 @@ public interface AerospikeOperations {
      * This operation requires Server version 6.0+.
      *
      * @param documents The documents to be deleted. Must not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch save succeeds, but results contain errors or null records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void deleteAll(Iterable<T> documents);
 
@@ -413,11 +433,11 @@ public interface AerospikeOperations {
      *
      * @param documents The documents to be deleted. Must not be {@literal null}.
      * @param setName   Set name to override the default set associated with the documents.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch delete results contain errors.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void deleteAll(Iterable<T> documents, String setName);
 
@@ -429,6 +449,7 @@ public interface AerospikeOperations {
      * @param id          The id of the record to be deleted. Must not be {@literal null}.
      * @param entityClass The class to extract set name from. Must not be {@literal null}.
      * @return Whether the record existed on server before deletion.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> boolean deleteById(Object id, Class<T> entityClass);
 
@@ -440,6 +461,7 @@ public interface AerospikeOperations {
      * @param id      The id of the record to be deleted. Must not be {@literal null}.
      * @param setName Set name to use.
      * @return Whether the record existed on server before deletion.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     boolean deleteById(Object id, String setName);
 
@@ -451,9 +473,9 @@ public interface AerospikeOperations {
      *
      * @param ids         The ids of the records to be deleted. Must not be {@literal null}.
      * @param entityClass The class to extract set name from. Must not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch delete results contain errors.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void deleteByIds(Iterable<?> ids, Class<T> entityClass);
 
@@ -465,9 +487,9 @@ public interface AerospikeOperations {
      *
      * @param ids     The ids of the records to be deleted. Must not be {@literal null}.
      * @param setName Set name to use.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch delete results contain errors.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     void deleteByIds(Iterable<?> ids, String setName);
 
@@ -480,9 +502,9 @@ public interface AerospikeOperations {
      *
      * @param groupedKeys Keys grouped by document type. Must not be {@literal null}, groupedKeys.getEntitiesKeys() must
      *                    not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch delete results contain errors.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     void deleteByIds(GroupedKeys groupedKeys);
 
@@ -490,6 +512,7 @@ public interface AerospikeOperations {
      * Truncate/Delete all records in the set determined by the given entity class.
      *
      * @param entityClass The class to extract set name from. Must not be {@literal null}.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void deleteAll(Class<T> entityClass);
 
@@ -497,6 +520,7 @@ public interface AerospikeOperations {
      * Truncate/Delete all documents in the given set.
      *
      * @param setName Set name to truncate/delete all records in.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     void deleteAll(String setName);
 

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeOperations.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeOperations.java
@@ -24,6 +24,7 @@ import com.aerospike.client.query.Filter;
 import com.aerospike.client.query.IndexCollectionType;
 import com.aerospike.client.query.IndexType;
 import com.aerospike.client.query.ResultSet;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.aerospike.config.AerospikeDataSettings;
 import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 import org.springframework.data.aerospike.core.model.GroupedEntities;
@@ -102,6 +103,8 @@ public interface AerospikeOperations {
      * does not exist it will be created, otherwise updated (an "upsert").
      *
      * @param document The document to be saved. Must not be {@literal null}.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> void save(T document);
 
@@ -123,6 +126,8 @@ public interface AerospikeOperations {
      *
      * @param document The document to be saved. Must not be {@literal null}.
      * @param setName  Set name to override the set associated with the document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> void save(T document, String setName);
 
@@ -135,9 +140,11 @@ public interface AerospikeOperations {
      *
      * @param documents The documents to be saved. Must not be {@literal null}.
      * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
-     *                                                     records
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void saveAll(Iterable<T> documents);
 
@@ -152,9 +159,11 @@ public interface AerospikeOperations {
      * @param documents The documents to be saved. Must not be {@literal null}.
      * @param setName   Set name to override the default set associated with the documents.
      * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
-     *                                                     records
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void saveAll(Iterable<T> documents, String setName);
 
@@ -164,6 +173,8 @@ public interface AerospikeOperations {
      * If the document has version property it will be updated with the server's version after successful operation.
      *
      * @param document The document to be inserted. Must not be {@literal null}.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> void insert(T document);
 
@@ -175,6 +186,8 @@ public interface AerospikeOperations {
      *
      * @param document The document to be inserted. Must not be {@literal null}.
      * @param setName  Set name to override the set associated with the document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> void insert(T document, String setName);
 
@@ -187,9 +200,11 @@ public interface AerospikeOperations {
      *
      * @param documents Documents to be inserted. Must not be {@literal null}.
      * @throws AerospikeException.BatchRecordArray         if batch insert succeeds, but results contain errors or null
-     *                                                     records
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void insertAll(Iterable<? extends T> documents);
 
@@ -204,9 +219,11 @@ public interface AerospikeOperations {
      * @param documents Documents to be inserted. Must not be {@literal null}.
      * @param setName   Set name to override the set associated with the document.
      * @throws AerospikeException.BatchRecordArray         if batch insert succeeds, but results contain errors or null
-     *                                                     records
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void insertAll(Iterable<? extends T> documents, String setName);
 
@@ -238,6 +255,8 @@ public interface AerospikeOperations {
      * If document has version property it will be updated with the server's version after successful operation.
      *
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> void update(T document);
 
@@ -251,6 +270,8 @@ public interface AerospikeOperations {
      *
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
      * @param setName  Set name to override the set associated with the document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> void update(T document, String setName);
 
@@ -264,6 +285,8 @@ public interface AerospikeOperations {
      *
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
      * @param fields   Specific fields to update.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> void update(T document, Collection<String> fields);
 
@@ -278,6 +301,8 @@ public interface AerospikeOperations {
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
      * @param setName  Set name to override the set associated with the document.
      * @param fields   Specific fields to update.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> void update(T document, String setName, Collection<String> fields);
 
@@ -290,9 +315,11 @@ public interface AerospikeOperations {
      *
      * @param documents The documents that identify the records to be updated. Must not be {@literal null}.
      * @throws AerospikeException.BatchRecordArray         if batch update succeeds, but results contain errors or null
-     *                                                     records
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void updateAll(Iterable<T> documents);
 
@@ -307,9 +334,11 @@ public interface AerospikeOperations {
      * @param documents The documents that identify the records to be updated. Must not be {@literal null}.
      * @param setName   Set name to override the set associated with the document.
      * @throws AerospikeException.BatchRecordArray         if batch update succeeds, but results contain errors or null
-     *                                                     records
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void updateAll(Iterable<T> documents, String setName);
 
@@ -326,83 +355,134 @@ public interface AerospikeOperations {
      *
      * @param id          The id of the record to delete. Must not be {@literal null}.
      * @param entityClass The class to extract set name from. Must not be {@literal null}.
-     * @return whether the document existed on server before deletion.
+     * @return whether the record existed on server before deletion.
      * @deprecated since 4.6.0, use {@link AerospikeOperations#deleteById(Object, Class)} instead.
      */
     <T> boolean delete(Object id, Class<T> entityClass);
 
     /**
      * Delete a record using the document's id.
+     * <p>
+     * If the document has version property it will be compared with the corresponding record's version on server.
      *
      * @param document The document to get set name and id from. Must not be {@literal null}.
-     * @return Whether the document existed on server before deletion.
+     * @return Whether the record existed on server before deletion.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> boolean delete(T document);
 
     /**
      * Delete a record within the given set using the document's id.
+     * <p>
+     * If the document has version property it will be compared with the corresponding record's version on server.
      *
      * @param document The document to get id from. Must not be {@literal null}.
      * @param setName  Set name to use.
-     * @return Whether the document existed on server before deletion.
+     * @return Whether the record existed on server before deletion.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> boolean delete(T document, String setName);
 
+
+    /**
+     * Delete multiple records in one batch request. The policies are analogous to {@link #delete(Object)}.
+     * <p>
+     * The execution order is NOT preserved.
+     * <p>
+     * This operation requires Server version 6.0+.
+     *
+     * @param documents The documents to be deleted. Must not be {@literal null}.
+     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     */
+    <T> void deleteAll(Iterable<T> documents);
+
+    /**
+     * Delete multiple records within the given set (overrides the default set associated with the documents) in one
+     * batch request. The policies are analogous to {@link #delete(Object)}.
+     * <p>
+     * The execution order is NOT preserved.
+     * <p>
+     * This operation requires Server version 6.0+.
+     *
+     * @param documents The documents to be deleted. Must not be {@literal null}.
+     * @param setName   Set name to override the default set associated with the documents.
+     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     */
+    <T> void deleteAll(Iterable<T> documents, String setName);
+
     /**
      * Delete a record by id, set name will be determined by the given entityClass.
+     * <p>
+     * If the document has version property it is not compared with the corresponding record's version on server.
      *
      * @param id          The id of the record to be deleted. Must not be {@literal null}.
      * @param entityClass The class to extract set name from. Must not be {@literal null}.
-     * @return Whether the document existed on server before deletion.
+     * @return Whether the record existed on server before deletion.
      */
     <T> boolean deleteById(Object id, Class<T> entityClass);
 
     /**
      * Delete a record by id within the given set.
+     * <p>
+     * If the document has version property it is not compared with the corresponding record's version on server.
      *
      * @param id      The id of the record to be deleted. Must not be {@literal null}.
      * @param setName Set name to use.
-     * @return Whether the document existed on server before deletion.
+     * @return Whether the record existed on server before deletion.
      */
     boolean deleteById(Object id, String setName);
 
     /**
      * Delete records by ids using a single batch delete operation, set name will be determined by the given
-     * entityClass.
+     * entityClass. The policies are analogous to {@link #deleteById(Object, Class)}.
      * <p>
      * This operation requires Server version 6.0+.
      *
      * @param ids         The ids of the records to be deleted. Must not be {@literal null}.
      * @param entityClass The class to extract set name from. Must not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors
+     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> void deleteByIds(Iterable<?> ids, Class<T> entityClass);
 
     /**
-     * Delete records by ids within the given set using a single batch delete operation.
+     * Delete records by ids within the given set using a single batch delete operation. The policies are analogous to
+     * {@link #deleteById(Object, String)}.
      * <p>
      * This operation requires Server version 6.0+.
      *
      * @param ids     The ids of the records to be deleted. Must not be {@literal null}.
      * @param setName Set name to use.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors
+     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     void deleteByIds(Iterable<?> ids, String setName);
 
     /**
-     * Perform a single batch delete for records from different sets.
+     * Perform a single batch delete operation for records from different sets.
      * <p>
-     * This operation requires Server version 6.0+.
+     * Records' versions on server are not checked.
+     * <p>
+     * This operation requires Server 6.0+.
      *
      * @param groupedKeys Keys grouped by document type. Must not be {@literal null}, groupedKeys.getEntitiesKeys() must
      *                    not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors
+     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
      * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details)
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     void deleteByIds(GroupedKeys groupedKeys);
 

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -234,8 +234,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
         if (errorsFound) {
             if (casErrorDocumentId != null) {
-                throw getOptimisticLockingFailureException("Failed to " + operationType.toString() + " the " +
-                    "record with ID '" + casErrorDocumentId + "' due to versions mismatch", null);
+                throw getOptimisticLockingFailureException(("Failed to %s the record with ID '%s' due to " +
+                    "versions mismatch").formatted(operationType.toString(), casErrorDocumentId), null);
             }
             AerospikeException e = new AerospikeException("Errors during batch " + operationType);
             throw new AerospikeException.BatchRecordArray(batchWriteRecords.toArray(BatchRecord[]::new), e);
@@ -416,7 +416,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
     private boolean doDeleteWithVersionAndHandleCasError(AerospikeWriteData data) {
         try {
-            return client.delete(expectGenerationPolicy(data), data.getKey());
+            return client.delete(expectGenerationPolicy(data, RecordExistsAction.UPDATE_ONLY), data.getKey());
         } catch (AerospikeException e) {
             throw translateCasError(e, "Failed to delete record due to versions mismatch");
         }
@@ -424,7 +424,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
     private boolean doDeleteIgnoreVersionAndTranslateError(AerospikeWriteData data) {
         try {
-            return client.delete(ignoreGenerationPolicy(), data.getKey());
+            return client.delete(ignoreGenerationPolicy(data, RecordExistsAction.UPDATE_ONLY), data.getKey());
         } catch (AerospikeException e) {
             throw translateError(e);
         }

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -224,7 +224,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
                 if (!batchRecordFailed(data.batchRecord())) {
                     if (operationType != DELETE_OPERATION) updateVersion(data.document(), data.batchRecord().record);
                 } else {
-                    if (hasGenerationError(data.batchRecord())) {
+                    if (hasGenerationError(data.batchRecord().resultCode)) {
                         casErrorDocumentId = data.batchRecord().key.userKey.toString(); // ID can be a String or a
                         // primitive
                     }

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -225,8 +225,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
                     if (operationType != DELETE_OPERATION) updateVersion(data.document(), data.batchRecord().record);
                 } else {
                     if (hasGenerationError(data.batchRecord().resultCode)) {
-                        casErrorDocumentId = data.batchRecord().key.userKey.toString(); // ID can be a String or a
-                        // primitive
+                        // ID can be a String or a primitive
+                        casErrorDocumentId = data.batchRecord().key.userKey.toString();
                     }
                 }
             }
@@ -234,8 +234,9 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
 
         if (errorsFound) {
             if (casErrorDocumentId != null) {
-                throw getOptimisticLockingFailureException(("Failed to %s the record with ID '%s' due to " +
-                    "versions mismatch").formatted(operationType.toString(), casErrorDocumentId), null);
+                throw getOptimisticLockingFailureException(
+                    "Failed to %s the record with ID '%s' due to versions mismatch"
+                        .formatted(operationType, casErrorDocumentId), null);
             }
             AerospikeException e = new AerospikeException("Errors during batch " + operationType);
             throw new AerospikeException.BatchRecordArray(batchWriteRecords.toArray(BatchRecord[]::new), e);

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -224,7 +224,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
                 if (!batchRecordFailed(data.batchRecord())) {
                     if (operationType != DELETE_OPERATION) updateVersion(data.document(), data.batchRecord().record);
                 } else {
-                    if (hasGenerationError(data.batchRecord().resultCode)) {
+                    if (hasVersionError(data.batchRecord().resultCode)) {
                         // ID can be a String or a primitive
                         casErrorDocumentId = data.batchRecord().key.userKey.toString();
                     }
@@ -410,9 +410,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
         AerospikePersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(document.getClass());
         if (entity.hasVersionProperty()) {
             return doDeleteWithVersionAndHandleCasError(data);
-        } else {
-            return doDeleteIgnoreVersionAndTranslateError(data);
         }
+        return doDeleteIgnoreVersionAndTranslateError(data);
     }
 
     private boolean doDeleteWithVersionAndHandleCasError(AerospikeWriteData data) {

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -224,7 +224,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
                 if (!batchRecordFailed(data.batchRecord())) {
                     if (operationType != DELETE_OPERATION) updateVersion(data.document(), data.batchRecord().record);
                 } else {
-                    if (hasVersionError(data.batchRecord().resultCode)) {
+                    if (hasOptimisticLockingError(data.batchRecord().resultCode)) {
                         // ID can be a String or a primitive
                         casErrorDocumentId = data.batchRecord().key.userKey.toString();
                     }

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -198,14 +198,14 @@ abstract class BaseAerospikeTemplate {
     }
 
     RuntimeException translateCasError(AerospikeException e, String errMsg) {
-        if (e.getResultCode() == ResultCode.GENERATION_ERROR) {
+        if (hasGenerationError(e.getResultCode())) {
             return getOptimisticLockingFailureException(errMsg, e);
         }
         return translateError(e);
     }
 
-    protected boolean hasGenerationError(BatchRecord record) {
-        return record.resultCode == ResultCode.GENERATION_ERROR;
+    protected boolean hasGenerationError(int resultCode) {
+        return resultCode == ResultCode.GENERATION_ERROR;
     }
 
     protected OptimisticLockingFailureException getOptimisticLockingFailureException(String errMsg,

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -481,10 +481,8 @@ abstract class BaseAerospikeTemplate {
 
         if (entity.hasVersionProperty()) {
             policy = expectGenerationBatchPolicy(data, RecordExistsAction.UPDATE_ONLY);
-
         } else {
             policy = ignoreGenerationBatchPolicy(data, RecordExistsAction.UPDATE_ONLY);
-
         }
         operations = Operation.array(Operation.delete());
 

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -198,13 +198,13 @@ abstract class BaseAerospikeTemplate {
     }
 
     RuntimeException translateCasError(AerospikeException e, String errMsg) {
-        if (hasGenerationError(e.getResultCode())) {
+        if (hasVersionError(e.getResultCode())) {
             return getOptimisticLockingFailureException(errMsg, e);
         }
         return translateError(e);
     }
 
-    protected boolean hasGenerationError(int resultCode) {
+    protected boolean hasVersionError(int resultCode) {
         return List.of(ResultCode.GENERATION_ERROR, ResultCode.KEY_EXISTS_ERROR, ResultCode.KEY_NOT_FOUND_ERROR)
             .contains(resultCode);
     }

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -205,7 +205,8 @@ abstract class BaseAerospikeTemplate {
     }
 
     protected boolean hasGenerationError(int resultCode) {
-        return resultCode == ResultCode.GENERATION_ERROR;
+        return List.of(ResultCode.GENERATION_ERROR, ResultCode.KEY_EXISTS_ERROR, ResultCode.KEY_NOT_FOUND_ERROR)
+            .contains(resultCode);
     }
 
     protected OptimisticLockingFailureException getOptimisticLockingFailureException(String errMsg,

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -198,8 +198,7 @@ abstract class BaseAerospikeTemplate {
     }
 
     RuntimeException translateCasError(AerospikeException e, String errMsg) {
-        int code = e.getResultCode();
-        if (code == ResultCode.KEY_EXISTS_ERROR || code == ResultCode.GENERATION_ERROR) {
+        if (e.getResultCode() == ResultCode.GENERATION_ERROR) {
             return getOptimisticLockingFailureException(errMsg, e);
         }
         return translateError(e);

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -198,13 +198,13 @@ abstract class BaseAerospikeTemplate {
     }
 
     RuntimeException translateCasError(AerospikeException e, String errMsg) {
-        if (hasVersionError(e.getResultCode())) {
+        if (hasOptimisticLockingError(e.getResultCode())) {
             return getOptimisticLockingFailureException(errMsg, e);
         }
         return translateError(e);
     }
 
-    protected boolean hasVersionError(int resultCode) {
+    protected boolean hasOptimisticLockingError(int resultCode) {
         return List.of(ResultCode.GENERATION_ERROR, ResultCode.KEY_EXISTS_ERROR, ResultCode.KEY_NOT_FOUND_ERROR)
             .contains(resultCode);
     }

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeOperations.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeOperations.java
@@ -125,12 +125,11 @@ public interface ReactiveAerospikeOperations {
      *
      * @param documents The documents to be saved. Must not be {@literal null}.
      * @return A Flux of the saved documents
-     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch save succeeds, but results contain errors or null records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> saveAll(Iterable<T> documents);
 
@@ -145,12 +144,11 @@ public interface ReactiveAerospikeOperations {
      * @param documents The documents to be saved. Must not be {@literal null}.
      * @param setName   The set name to save to documents.
      * @return A Flux of the saved documents
-     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch save succeeds, but results contain errors or null records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> saveAll(Iterable<T> documents, String setName);
 
@@ -193,12 +191,12 @@ public interface ReactiveAerospikeOperations {
      *
      * @param documents Documents to insert. Must not be {@literal null}.
      * @return A Flux of the inserted documents
-     * @throws AerospikeException.BatchRecordArray         if batch insert succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch insert succeeds, but results contain errors or null
+     *                                             records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> insertAll(Iterable<? extends T> documents);
 
@@ -213,12 +211,12 @@ public interface ReactiveAerospikeOperations {
      * @param documents Documents to insert. Must not be {@literal null}.
      * @param setName   The set name to insert the documents.
      * @return A Flux of the inserted documents
-     * @throws AerospikeException.BatchRecordArray         if batch insert succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch insert succeeds, but results contain errors or null
+     *                                             records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> insertAll(Iterable<? extends T> documents, String setName);
 
@@ -325,12 +323,12 @@ public interface ReactiveAerospikeOperations {
      *
      * @param documents The documents that identify the records to be updated. Must not be {@literal null}.
      * @return A Flux of the updated documents
-     * @throws AerospikeException.BatchRecordArray         if batch update succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch update succeeds, but results contain errors or null
+     *                                             records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> updateAll(Iterable<? extends T> documents);
 
@@ -345,12 +343,12 @@ public interface ReactiveAerospikeOperations {
      * @param documents The documents that identify the records to be updated. Must not be {@literal null}.
      * @param setName   The set name to update the documents.
      * @return A Flux of the updated documents
-     * @throws AerospikeException.BatchRecordArray         if batch update succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch update succeeds, but results contain errors or null
+     *                                             records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> updateAll(Iterable<? extends T> documents, String setName);
 
@@ -407,12 +405,11 @@ public interface ReactiveAerospikeOperations {
      * This operation requires Server version 6.0+.
      *
      * @param documents The documents to be deleted. Must not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
-     *                                                     records.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch save succeeds, but results contain errors or null records.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Mono<Void> deleteAll(Iterable<T> documents);
 
@@ -426,11 +423,11 @@ public interface ReactiveAerospikeOperations {
      *
      * @param documents The documents to be deleted. Must not be {@literal null}.
      * @param setName   Set name to override the default set associated with the documents.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
-     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
-     *                                                     different value from that found on server.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch delete results contain errors.
+     * @throws OptimisticLockingFailureException   if at least one document has a version attribute with a different
+     *                                             value from that found on server.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Mono<Void> deleteAll(Iterable<T> documents, String setName);
 
@@ -467,9 +464,9 @@ public interface ReactiveAerospikeOperations {
      * @param ids         The ids of the records to find. Must not be {@literal null}.
      * @param entityClass The class to extract the Aerospike set name from and to map the results to. Must not be
      *                    {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch delete results contain errors.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Mono<Void> deleteByIds(Iterable<?> ids, Class<T> entityClass);
 
@@ -481,9 +478,9 @@ public interface ReactiveAerospikeOperations {
      *
      * @param ids     The ids of the documents to find. Must not be {@literal null}.
      * @param setName Set name to use.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch delete results contain errors.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     Mono<Void> deleteByIds(Iterable<?> ids, String setName);
 
@@ -496,9 +493,9 @@ public interface ReactiveAerospikeOperations {
      *
      * @param groupedKeys Keys grouped by document type. Must not be {@literal null}, groupedKeys.getEntitiesKeys() must
      *                    not be {@literal null}.
-     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
-     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
-     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     * @throws AerospikeException.BatchRecordArray if batch delete results contain errors.
+     * @throws DataAccessException                 if batch operation failed (see
+     *                                             {@link DefaultAerospikeExceptionTranslator} for details).
      */
     Mono<Void> deleteByIds(GroupedKeys groupedKeys);
 

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeOperations.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeOperations.java
@@ -21,6 +21,7 @@ import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.IndexCollectionType;
 import com.aerospike.client.query.IndexType;
 import com.aerospike.client.reactor.IAerospikeReactorClient;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.aerospike.config.AerospikeDataSettings;
 import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
@@ -84,6 +85,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of the new saved document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<T> save(T document);
 
@@ -108,6 +111,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of the new saved document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<T> save(T document, String setName);
 
@@ -158,6 +163,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of the new inserted document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<T> insert(T document);
 
@@ -172,6 +179,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of the new inserted document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<T> insert(T document, String setName);
 
@@ -220,6 +229,7 @@ public interface ReactiveAerospikeOperations {
      * @param writePolicy The Aerospike write policy for the inner Aerospike put operation. Must not be
      *                    {@literal null}.
      * @return A Mono of the new persisted document.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Mono<T> persist(T document, WritePolicy writePolicy);
 
@@ -232,6 +242,7 @@ public interface ReactiveAerospikeOperations {
      *                    {@literal null}.
      * @param setName     Set name to override the set associated with the document.
      * @return A Mono of the new persisted document.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Mono<T> persist(T document, WritePolicy writePolicy, String setName);
 
@@ -247,6 +258,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of the new updated document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<T> update(T document);
 
@@ -263,6 +276,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of the new updated document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<T> update(T document, String setName);
 
@@ -278,6 +293,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of the new updated document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<T> update(T document, Collection<String> fields);
 
@@ -294,6 +311,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of the new updated document.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<T> update(T document, String setName, Collection<String> fields);
 
@@ -362,6 +381,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of whether the record existed on server before deletion.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<Boolean> delete(T document);
 
@@ -373,6 +394,8 @@ public interface ReactiveAerospikeOperations {
      * @return A Mono of whether the record existed on server before deletion.
      * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
      *                                           that found on server.
+     * @throws DataAccessException               if operation failed (see {@link DefaultAerospikeExceptionTranslator}
+     *                                           for details).
      */
     <T> Mono<Boolean> delete(T document, String setName);
 
@@ -419,6 +442,7 @@ public interface ReactiveAerospikeOperations {
      * @param id          The id of the record to be deleted. Must not be {@literal null}.
      * @param entityClass The class to extract the Aerospike set name from. Must not be {@literal null}.
      * @return A Mono of whether the record existed on server before deletion.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Mono<Boolean> deleteById(Object id, Class<T> entityClass);
 
@@ -430,6 +454,7 @@ public interface ReactiveAerospikeOperations {
      * @param id      The id of the record to be deleted. Must not be {@literal null}.
      * @param setName Set name to use.
      * @return A Mono of whether the record existed on server before deletion.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     Mono<Boolean> deleteById(Object id, String setName);
 
@@ -471,8 +496,9 @@ public interface ReactiveAerospikeOperations {
      *
      * @param groupedKeys Keys grouped by document type. Must not be {@literal null}, groupedKeys.getEntitiesKeys() must
      *                    not be {@literal null}.
-     * @return onError is signalled with {@link AerospikeException.BatchRecordArray} if batch delete results contain
-     * errors, or with {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     Mono<Void> deleteByIds(GroupedKeys groupedKeys);
 
@@ -480,6 +506,7 @@ public interface ReactiveAerospikeOperations {
      * Reactively truncate/delete all records in the set determined by the given entity class.
      *
      * @param entityClass The class to extract set name from. Must not be {@literal null}.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Mono<Void> deleteAll(Class<T> entityClass);
 
@@ -487,6 +514,7 @@ public interface ReactiveAerospikeOperations {
      * Reactively truncate/delete all the documents in the given set.
      *
      * @param setName Set name to use.
+     * @throws DataAccessException if operation failed (see {@link DefaultAerospikeExceptionTranslator} for details).
      */
     Mono<Void> deleteAll(String setName);
 

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeOperations.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeOperations.java
@@ -21,6 +21,7 @@ import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.IndexCollectionType;
 import com.aerospike.client.query.IndexType;
 import com.aerospike.client.reactor.IAerospikeReactorClient;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.aerospike.config.AerospikeDataSettings;
 import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 import org.springframework.data.aerospike.core.model.GroupedEntities;
@@ -81,6 +82,8 @@ public interface ReactiveAerospikeOperations {
      *
      * @param document The document to be saved. Must not be {@literal null}.
      * @return A Mono of the new saved document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<T> save(T document);
 
@@ -103,6 +106,8 @@ public interface ReactiveAerospikeOperations {
      * @param document The document to be saved. Must not be {@literal null}.
      * @param setName  The set name to save the document.
      * @return A Mono of the new saved document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<T> save(T document, String setName);
 
@@ -114,9 +119,13 @@ public interface ReactiveAerospikeOperations {
      * Requires Server version 6.0+.
      *
      * @param documents The documents to be saved. Must not be {@literal null}.
-     * @return A Flux of the saved documents, otherwise onError is signalled with
-     * {@link AerospikeException.BatchRecordArray} if batch save results contain errors, or with
-     * {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @return A Flux of the saved documents
+     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> saveAll(Iterable<T> documents);
 
@@ -130,9 +139,13 @@ public interface ReactiveAerospikeOperations {
      *
      * @param documents The documents to be saved. Must not be {@literal null}.
      * @param setName   The set name to save to documents.
-     * @return A Flux of the saved documents, otherwise onError is signalled with
-     * {@link AerospikeException.BatchRecordArray} if batch save results contain errors, or with
-     * {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @return A Flux of the saved documents
+     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> saveAll(Iterable<T> documents, String setName);
 
@@ -143,6 +156,8 @@ public interface ReactiveAerospikeOperations {
      *
      * @param document The document to be inserted. Must not be {@literal null}.
      * @return A Mono of the new inserted document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<T> insert(T document);
 
@@ -155,6 +170,8 @@ public interface ReactiveAerospikeOperations {
      * @param document The document to be inserted. Must not be {@literal null}.
      * @param setName  The set name to insert the document.
      * @return A Mono of the new inserted document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<T> insert(T document, String setName);
 
@@ -166,9 +183,13 @@ public interface ReactiveAerospikeOperations {
      * Requires Server version 6.0+.
      *
      * @param documents Documents to insert. Must not be {@literal null}.
-     * @return A Flux of the inserted documents, otherwise onError is signalled with
-     * {@link AerospikeException.BatchRecordArray} if batch insert results contain errors, or with
-     * {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @return A Flux of the inserted documents
+     * @throws AerospikeException.BatchRecordArray         if batch insert succeeds, but results contain errors or null
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> insertAll(Iterable<? extends T> documents);
 
@@ -182,9 +203,13 @@ public interface ReactiveAerospikeOperations {
      *
      * @param documents Documents to insert. Must not be {@literal null}.
      * @param setName   The set name to insert the documents.
-     * @return A Flux of the inserted documents, otherwise onError is signalled with
-     * {@link AerospikeException.BatchRecordArray} if batch insert results contain errors, or with
-     * {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @return A Flux of the inserted documents
+     * @throws AerospikeException.BatchRecordArray         if batch insert succeeds, but results contain errors or null
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> insertAll(Iterable<? extends T> documents, String setName);
 
@@ -220,6 +245,8 @@ public interface ReactiveAerospikeOperations {
      *
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
      * @return A Mono of the new updated document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<T> update(T document);
 
@@ -234,6 +261,8 @@ public interface ReactiveAerospikeOperations {
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
      * @param setName  The set name to update the document.
      * @return A Mono of the new updated document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<T> update(T document, String setName);
 
@@ -247,6 +276,8 @@ public interface ReactiveAerospikeOperations {
      *
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
      * @return A Mono of the new updated document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<T> update(T document, Collection<String> fields);
 
@@ -261,6 +292,8 @@ public interface ReactiveAerospikeOperations {
      * @param document The document that identifies the record to be updated. Must not be {@literal null}.
      * @param setName  The set name to update the document.
      * @return A Mono of the new updated document.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<T> update(T document, String setName, Collection<String> fields);
 
@@ -272,9 +305,13 @@ public interface ReactiveAerospikeOperations {
      * Requires Server version 6.0+.
      *
      * @param documents The documents that identify the records to be updated. Must not be {@literal null}.
-     * @return A Flux of the updated documents, otherwise onError is signalled with
-     * {@link AerospikeException.BatchRecordArray} if batch update results contain errors, or with
-     * {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @return A Flux of the updated documents
+     * @throws AerospikeException.BatchRecordArray         if batch update succeeds, but results contain errors or null
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> updateAll(Iterable<? extends T> documents);
 
@@ -288,9 +325,13 @@ public interface ReactiveAerospikeOperations {
      *
      * @param documents The documents that identify the records to be updated. Must not be {@literal null}.
      * @param setName   The set name to update the documents.
-     * @return A Flux of the updated documents, otherwise onError is signalled with
-     * {@link AerospikeException.BatchRecordArray} if batch update results contain errors, or with
-     * {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @return A Flux of the updated documents
+     * @throws AerospikeException.BatchRecordArray         if batch update succeeds, but results contain errors or null
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Flux<T> updateAll(Iterable<? extends T> documents, String setName);
 
@@ -314,9 +355,13 @@ public interface ReactiveAerospikeOperations {
 
     /**
      * Reactively delete a record using the document's id.
+     * <p>
+     * If the document has version property it will be compared with the corresponding record's version on server.
      *
      * @param document The document to get set name and id from. Must not be {@literal null}.
-     * @return A Mono of whether the document existed on server before deletion.
+     * @return A Mono of whether the record existed on server before deletion.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<Boolean> delete(T document);
 
@@ -325,56 +370,102 @@ public interface ReactiveAerospikeOperations {
      *
      * @param document The document to get id from. Must not be {@literal null}.
      * @param setName  Set name to use.
-     * @return A Mono of whether the document existed on server before deletion.
+     * @return A Mono of whether the record existed on server before deletion.
+     * @throws OptimisticLockingFailureException if the document has a version attribute with a different value from
+     *                                           that found on server.
      */
     <T> Mono<Boolean> delete(T document, String setName);
 
     /**
+     * Reactively delete multiple records in one batch request. The policies are analogous to {@link #delete(Object)}.
+     * <p>
+     * The execution order is NOT preserved.
+     * <p>
+     * This operation requires Server version 6.0+.
+     *
+     * @param documents The documents to be deleted. Must not be {@literal null}.
+     * @throws AerospikeException.BatchRecordArray         if batch save succeeds, but results contain errors or null
+     *                                                     records.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     */
+    <T> Mono<Void> deleteAll(Iterable<T> documents);
+
+    /**
+     * Reactively delete multiple records within the given set (overrides the default set associated with the documents)
+     * in one batch request. The policies are analogous to {@link #delete(Object)}.
+     * <p>
+     * The execution order is NOT preserved.
+     * <p>
+     * This operation requires Server version 6.0+.
+     *
+     * @param documents The documents to be deleted. Must not be {@literal null}.
+     * @param setName   Set name to override the default set associated with the documents.
+     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
+     * @throws OptimisticLockingFailureException           if at least one document has a version attribute with a
+     *                                                     different value from that found on server.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
+     */
+    <T> Mono<Void> deleteAll(Iterable<T> documents, String setName);
+
+    /**
      * Reactively delete a record by id, set name will be determined by the given entity class.
+     * <p>
+     * If the document has version property it is not compared with the corresponding record's version on server.
      *
      * @param id          The id of the record to be deleted. Must not be {@literal null}.
      * @param entityClass The class to extract the Aerospike set name from. Must not be {@literal null}.
-     * @return A Mono of whether the document existed on server before deletion.
+     * @return A Mono of whether the record existed on server before deletion.
      */
     <T> Mono<Boolean> deleteById(Object id, Class<T> entityClass);
 
     /**
-     * Reactively delete a record within the given set by id.
+     * Reactively delete a record by id within the given set.
+     * <p>
+     * If the document has version property it is not compared with the corresponding record's version on server.
      *
      * @param id      The id of the record to be deleted. Must not be {@literal null}.
      * @param setName Set name to use.
-     * @return A Mono of whether the document existed on server before deletion.
+     * @return A Mono of whether the record existed on server before deletion.
      */
     Mono<Boolean> deleteById(Object id, String setName);
 
     /**
      * Reactively delete records using a single batch delete operation, set name will be determined by the given entity
-     * class.
+     * class. The policies are analogous to {@link #deleteById(Object, Class)}.
      * <p>
      * This operation requires Server version 6.0+.
      *
      * @param ids         The ids of the records to find. Must not be {@literal null}.
      * @param entityClass The class to extract the Aerospike set name from and to map the results to. Must not be
      *                    {@literal null}.
-     * @return onError is signalled with {@link AerospikeException.BatchRecordArray} if batch delete results contain
-     * errors, or with {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     <T> Mono<Void> deleteByIds(Iterable<?> ids, Class<T> entityClass);
 
     /**
-     * Reactively delete records within the given set using a single batch delete operation.
+     * Reactively delete records within the given set using a single batch delete operation. The policies are analogous
+     * to {@link #deleteById(Object, String)}.
      * <p>
      * This operation requires Server version 6.0+.
      *
      * @param ids     The ids of the documents to find. Must not be {@literal null}.
      * @param setName Set name to use.
-     * @return onError is signalled with {@link AerospikeException.BatchRecordArray} if batch delete results contain
-     * errors, or with {@link org.springframework.dao.DataAccessException} if batch operation failed.
+     * @throws AerospikeException.BatchRecordArray         if batch delete results contain errors.
+     * @throws org.springframework.dao.DataAccessException if batch operation failed (see
+     *                                                     {@link DefaultAerospikeExceptionTranslator} for details).
      */
     Mono<Void> deleteByIds(Iterable<?> ids, String setName);
 
     /**
      * Reactively delete records from different sets in a single request.
+     * <p>
+     * Records' versions on server are not checked.
      * <p>
      * This operation requires Server version 6.0+.
      *

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -219,7 +219,7 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
                 if (!batchRecordFailed(data.batchRecord())) {
                     if (operationType != DELETE_OPERATION) updateVersion(data.document(), data.batchRecord().record);
                 } else {
-                    if (hasGenerationError(data.batchRecord().resultCode)) {
+                    if (hasVersionError(data.batchRecord().resultCode)) {
                         // ID can be a String or a primitive
                         casErrorDocumentId = data.batchRecord().key.userKey.toString();
                     }
@@ -421,12 +421,11 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
                 .delete(expectGenerationPolicy(data), data.getKey())
                 .hasElement()
                 .onErrorMap(e -> translateCasThrowable(e, DELETE_OPERATION.toString()));
-        } else {
-            return reactorClient
-                .delete(ignoreGenerationPolicy(), data.getKey())
-                .hasElement()
-                .onErrorMap(this::translateError);
         }
+        return reactorClient
+            .delete(ignoreGenerationPolicy(), data.getKey())
+            .hasElement()
+            .onErrorMap(this::translateError);
     }
 
     @Override

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -419,12 +419,12 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
         if (entity.hasVersionProperty()) {
             return reactorClient
                 .delete(expectGenerationPolicy(data), data.getKey())
-                .map(Objects::nonNull)
+                .hasElement()
                 .onErrorMap(e -> translateCasThrowable(e, DELETE_OPERATION.toString()));
         } else {
             return reactorClient
                 .delete(ignoreGenerationPolicy(), data.getKey())
-                .map(Objects::nonNull)
+                .hasElement()
                 .onErrorMap(this::translateError);
         }
     }

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -219,7 +219,7 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
                 if (!batchRecordFailed(data.batchRecord())) {
                     if (operationType != DELETE_OPERATION) updateVersion(data.document(), data.batchRecord().record);
                 } else {
-                    if (hasGenerationError(data.batchRecord())) {
+                    if (hasGenerationError(data.batchRecord().resultCode)) {
                         casErrorDocumentId = data.batchRecord().key.userKey.toString(); // ID can be a String or a
                         // primitive
                     }

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -219,7 +219,7 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
                 if (!batchRecordFailed(data.batchRecord())) {
                     if (operationType != DELETE_OPERATION) updateVersion(data.document(), data.batchRecord().record);
                 } else {
-                    if (hasVersionError(data.batchRecord().resultCode)) {
+                    if (hasOptimisticLockingError(data.batchRecord().resultCode)) {
                         // ID can be a String or a primitive
                         casErrorDocumentId = data.batchRecord().key.userKey.toString();
                     }

--- a/src/main/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepository.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepository.java
@@ -27,7 +27,6 @@ import org.springframework.data.keyvalue.core.IterableConverter;
 import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.util.Assert;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -129,12 +128,7 @@ public class SimpleAerospikeRepository<T, ID> implements AerospikeRepository<T, 
     @Override
     public void deleteAll(Iterable<? extends T> entities) {
         Assert.notNull(entities, "The given entities for deleting must not be null!");
-        List<Object> ids = new ArrayList<>();
-        entities.forEach(entity -> {
-            Assert.notNull(entity, "The given Iterable of entities must not contain null!");
-            ids.add(entityInformation.getId(entity));
-        });
-        operations.deleteByIds(ids, entityInformation.getJavaType());
+        operations.deleteAll(entities);
     }
 
     @Override

--- a/src/main/java/org/springframework/data/aerospike/repository/support/SimpleReactiveAerospikeRepository.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/support/SimpleReactiveAerospikeRepository.java
@@ -26,9 +26,6 @@ import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Stub implementation of {@link ReactiveAerospikeRepository}.
  *
@@ -132,12 +129,7 @@ public class SimpleReactiveAerospikeRepository<T, ID> implements ReactiveAerospi
     @Override
     public Mono<Void> deleteAll(Iterable<? extends T> entities) {
         Assert.notNull(entities, "The given Iterable of entities must not be null!");
-        List<Object> ids = new ArrayList<>();
-        entities.forEach(entity -> {
-            Assert.notNull(entity, "The given Iterable of entities must not contain null!");
-            ids.add(entityInformation.getId(entity));
-        });
-        return operations.deleteByIds(ids, entityInformation.getJavaType());
+        return operations.deleteAll(entities);
     }
 
     @Override

--- a/src/main/java/org/springframework/data/aerospike/utility/Utils.java
+++ b/src/main/java/org/springframework/data/aerospike/utility/Utils.java
@@ -50,7 +50,7 @@ public class Utils {
         String[] messages = new String[client.getNodes().length];
         int index = 0;
         for (Node node : client.getNodes()) {
-            messages[index] = Info.request(node, infoString);
+            messages[index] = Info.request(client.getInfoPolicyDefault(), node, infoString);
         }
         return messages;
     }

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateDeleteTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateDeleteTests.java
@@ -53,18 +53,18 @@ public class AerospikeTemplateDeleteTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void deleteByObject_ignoresDocumentVersionEvenIfDefaultGenerationPolicyIsSet() {
-        GenerationPolicy initialGenerationPolicy = client.getWritePolicyDefault().generationPolicy;
-        client.getWritePolicyDefault().generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;
-        try {
-            VersionedClass initialDocument = new VersionedClass(id, "a");
-            template.insert(initialDocument);
-            template.update(new VersionedClass(id, "b", initialDocument.getVersion()));
-
-            boolean deleted = template.delete(initialDocument);
-            assertThat(deleted).isTrue();
-        } finally {
-            client.getWritePolicyDefault().generationPolicy = initialGenerationPolicy;
-        }
+//        GenerationPolicy initialGenerationPolicy = client.getWritePolicyDefault().generationPolicy;
+//        client.getWritePolicyDefault().generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;
+//        try {
+//            VersionedClass initialDocument = new VersionedClass(id, "a");
+//            template.insert(initialDocument);
+//            template.update(new VersionedClass(id, "b", initialDocument.getVersion()));
+//
+//            boolean deleted = template.delete(initialDocument);
+//            assertThat(deleted).isTrue();
+//        } finally {
+//            client.getWritePolicyDefault().generationPolicy = initialGenerationPolicy;
+//        }
     }
 
     @Test

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateDeleteTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateDeleteTests.java
@@ -122,11 +122,7 @@ public class AerospikeTemplateDeleteTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void deleteByObject_VersionsMismatch() {
-        Person person = new Person(id, "QLastName", 21);
         VersionedClass versionedDocument = new VersionedClass(nextId(), "test");
-
-        assertThat(template.delete(person)).isFalse();
-        assertThat(template.delete(versionedDocument)).isFalse();
 
         template.insert(versionedDocument);
         versionedDocument.setVersion(2);
@@ -176,6 +172,9 @@ public class AerospikeTemplateDeleteTests extends BaseBlockingIntegrationTests {
     @Test
     public void deleteById_returnsFalseIfValueIsAbsent() {
         assertThat(template.deleteById(id, Person.class)).isFalse();
+
+        assertThat(template.delete(new Person(id, "QLastName", 21))).isFalse();
+        assertThat(template.delete(new VersionedClass(nextId(), "test"))).isFalse();
     }
 
     @Test

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateDeleteTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateDeleteTests.java
@@ -52,22 +52,6 @@ public class AerospikeTemplateDeleteTests extends BaseBlockingIntegrationTests {
     }
 
     @Test
-    public void deleteByObject_ignoresDocumentVersionEvenIfDefaultGenerationPolicyIsSet() {
-//        GenerationPolicy initialGenerationPolicy = client.getWritePolicyDefault().generationPolicy;
-//        client.getWritePolicyDefault().generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;
-//        try {
-//            VersionedClass initialDocument = new VersionedClass(id, "a");
-//            template.insert(initialDocument);
-//            template.update(new VersionedClass(id, "b", initialDocument.getVersion()));
-//
-//            boolean deleted = template.delete(initialDocument);
-//            assertThat(deleted).isTrue();
-//        } finally {
-//            client.getWritePolicyDefault().generationPolicy = initialGenerationPolicy;
-//        }
-    }
-
-    @Test
     public void deleteByObject_ignoresVersionEvenIfDefaultGenerationPolicyIsSet() {
         GenerationPolicy initialGenerationPolicy = client.getWritePolicyDefault().generationPolicy;
         client.getWritePolicyDefault().generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.aerospike.core;
 
-import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
 import com.aerospike.client.policy.Policy;
@@ -23,8 +22,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.dao.ConcurrencyFailureException;
-import org.springframework.dao.DataRetrievalFailureException;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.aerospike.BaseBlockingIntegrationTests;
 import org.springframework.data.aerospike.sample.Person;
@@ -118,8 +115,7 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
         template.save(new VersionedClass(id, "foo"));
 
         assertThatThrownBy(() -> template.save(new VersionedClass(id, "foo")))
-//            .isInstanceOf(OptimisticLockingFailureException.class);
-            .isInstanceOf(DuplicateKeyException.class);
+            .isInstanceOf(OptimisticLockingFailureException.class);
     }
 
     @Test
@@ -149,8 +145,8 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void shouldFailSaveNewDocumentWithVersionGreaterThanZero() {
-        assertThatThrownBy(() -> template.save(new VersionedClass(id, "foo", 5L)))
-            .isInstanceOf(DataRetrievalFailureException.class);
+        assertThatThrownBy(() -> template.save(new VersionedClass(nextId(), "foo", 5L)))
+            .isInstanceOf(OptimisticLockingFailureException.class);
     }
 
     @Test
@@ -259,8 +255,7 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
             VersionedClass messageData = new VersionedClass(id, data);
             try {
                 template.save(messageData);
-//            } catch (OptimisticLockingFailureException e) {
-            } catch (DuplicateKeyException e) {
+            } catch (OptimisticLockingFailureException e) {
                 optimisticLockCounter.incrementAndGet();
             }
         });
@@ -311,7 +306,7 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
                     }
 
                     template.save(toUpdate);
-                } catch (ConcurrencyFailureException | DuplicateKeyException e) {
+                } catch (ConcurrencyFailureException e) {
                     // try again
                     run();
                 }
@@ -378,15 +373,15 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
     public void shouldSaveAllVersionedDocumentsAndSetVersionAndThrowExceptionIfAlreadyExist() {
         // batch write operations are supported starting with Server version 6.0+
         if (serverVersionSupport.batchWrite()) {
-            VersionedClass first = new VersionedClass(id, "foo");
-            VersionedClass second = new VersionedClass(nextId(), "foo");
+            VersionedClass first = new VersionedClass("as-5279", "foo");
+            VersionedClass second = new VersionedClass("as-5277", "foo");
 
             assertThat(first.getVersion() == 0).isTrue();
             assertThat(second.getVersion() == 0).isTrue();
 
             assertThatThrownBy(() -> template.saveAll(List.of(first, first, second, second)))
-                .isInstanceOf(AerospikeException.BatchRecordArray.class)
-                .hasMessageContaining("Errors during batch save");
+                .isInstanceOf(OptimisticLockingFailureException.class)
+                .hasMessageFindingMatch("Failed to save the record with ID .* due to versions mismatch");
 
             assertThat(first.getVersion() == 1).isTrue();
             assertThat(second.getVersion() == 1).isTrue();

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
@@ -22,8 +22,8 @@ import com.aerospike.client.policy.Policy;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.aerospike.BaseBlockingIntegrationTests;
 import org.springframework.data.aerospike.sample.Person;
@@ -117,7 +117,8 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
         template.save(new VersionedClass(id, "foo"));
 
         assertThatThrownBy(() -> template.save(new VersionedClass(id, "foo")))
-            .isInstanceOf(OptimisticLockingFailureException.class);
+//            .isInstanceOf(OptimisticLockingFailureException.class);
+            .isInstanceOf(DuplicateKeyException.class);
     }
 
     @Test
@@ -257,7 +258,8 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
             VersionedClass messageData = new VersionedClass(id, data);
             try {
                 template.save(messageData);
-            } catch (OptimisticLockingFailureException e) {
+//            } catch (OptimisticLockingFailureException e) {
+            } catch (DuplicateKeyException e) {
                 optimisticLockCounter.incrementAndGet();
             }
         });
@@ -308,7 +310,8 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
                     }
 
                     template.save(toUpdate);
-                } catch (ConcurrencyFailureException e) {
+//                } catch (ConcurrencyFailureException e) {
+                } catch (DuplicateKeyException e) {
                     // try again
                     run();
                 }

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateSaveTests.java
@@ -22,6 +22,7 @@ import com.aerospike.client.policy.Policy;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -296,8 +297,8 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
 
     @Test
     public void shouldConcurrentlyUpdateDocumentIfTouchOnReadIsTrue() {
-        int numberOfConcurrentUpdate = 10;
-        AsyncUtils.executeConcurrently(numberOfConcurrentUpdate, new Runnable() {
+        int numberOfConcurrentUpdates = 10;
+        AsyncUtils.executeConcurrently(numberOfConcurrentUpdates, new Runnable() {
             @Override
             public void run() {
                 try {
@@ -310,8 +311,7 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
                     }
 
                     template.save(toUpdate);
-//                } catch (ConcurrencyFailureException e) {
-                } catch (DuplicateKeyException e) {
+                } catch (ConcurrencyFailureException | DuplicateKeyException e) {
                     // try again
                     run();
                 }
@@ -319,7 +319,7 @@ public class AerospikeTemplateSaveTests extends BaseBlockingIntegrationTests {
         });
 
         DocumentWithTouchOnRead actual = template.findById(id, DocumentWithTouchOnRead.class);
-        assertThat(actual.getField()).isEqualTo(numberOfConcurrentUpdate);
+        assertThat(actual.getField()).isEqualTo(numberOfConcurrentUpdates);
     }
 
     @Test

--- a/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateDeleteRelatedTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateDeleteRelatedTests.java
@@ -34,23 +34,6 @@ import static org.springframework.data.aerospike.sample.SampleClasses.VersionedC
 public class ReactiveAerospikeTemplateDeleteRelatedTests extends BaseReactiveIntegrationTests {
 
     @Test
-    public void deleteByObject_ignoresDocumentVersionEvenIfDefaultGenerationPolicyIsSet() {
-//        WritePolicy writePolicyDefault = reactorClient.getWritePolicyDefault();
-//        GenerationPolicy initialGenerationPolicy = writePolicyDefault.generationPolicy;
-//        writePolicyDefault.generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;
-//        try {
-//            VersionedClass initialDocument = new VersionedClass(id, "a");
-//            reactiveTemplate.insert(initialDocument).block();
-//            reactiveTemplate.update(new VersionedClass(id, "b", initialDocument.getVersion())).block();
-//
-//            Mono<Boolean> deleted = reactiveTemplate.delete(initialDocument).subscribeOn(Schedulers.parallel());
-//            StepVerifier.create(deleted).expectNext(true).verifyComplete();
-//        } finally {
-//            writePolicyDefault.generationPolicy = initialGenerationPolicy;
-//        }
-    }
-
-    @Test
     public void deleteByObject_ignoresVersionEvenIfDefaultGenerationPolicyIsSet() {
         WritePolicy writePolicyDefault = reactorClient.getWritePolicyDefault();
         GenerationPolicy initialGenerationPolicy = writePolicyDefault.generationPolicy;
@@ -137,9 +120,8 @@ public class ReactiveAerospikeTemplateDeleteRelatedTests extends BaseReactiveInt
         // then
         StepVerifier.create(deleted).expectComplete().verify();
 
-//        assertThat(reactiveTemplate.delete(new Person(id, "QLastName", 21)).block()).isFalse();
-//        assertThat(reactiveTemplate.delete(new VersionedClass(nextId(), "test")).block()).isFalse();
-
+        assertThat(reactiveTemplate.delete(new Person(id, "QLastName", 21)).block()).isFalse();
+        assertThat(reactiveTemplate.delete(new VersionedClass(nextId(), "test")).block()).isFalse();
     }
 
     @Test
@@ -160,7 +142,7 @@ public class ReactiveAerospikeTemplateDeleteRelatedTests extends BaseReactiveInt
         Mono<Boolean> deleted = reactiveTemplate.delete(person).subscribeOn(Schedulers.parallel());
 
         // then
-        StepVerifier.create(deleted).expectComplete().verify();
+        StepVerifier.create(deleted).expectNext(false);
     }
 
     @Test

--- a/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateDeleteRelatedTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateDeleteRelatedTests.java
@@ -121,11 +121,7 @@ public class ReactiveAerospikeTemplateDeleteRelatedTests extends BaseReactiveInt
 
     @Test
     public void deleteByObject_VersionsMismatch() {
-        Person person = new Person(id, "QLastName", 21);
         VersionedClass versionedDocument = new VersionedClass(nextId(), "test");
-
-        assertThat(reactiveTemplate.delete(person).block()).isFalse();
-        assertThat(reactiveTemplate.delete(versionedDocument).block()).isFalse();
 
         reactiveTemplate.insert(versionedDocument).block();
         versionedDocument.setVersion(2);
@@ -138,9 +134,12 @@ public class ReactiveAerospikeTemplateDeleteRelatedTests extends BaseReactiveInt
     public void deleteById_shouldReturnFalseIfValueIsAbsent() {
         // when
         Mono<Boolean> deleted = reactiveTemplate.deleteById(id, Person.class).subscribeOn(Schedulers.parallel());
-
         // then
         StepVerifier.create(deleted).expectComplete().verify();
+
+//        assertThat(reactiveTemplate.delete(new Person(id, "QLastName", 21)).block()).isFalse();
+//        assertThat(reactiveTemplate.delete(new VersionedClass(nextId(), "test")).block()).isFalse();
+
     }
 
     @Test

--- a/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateDeleteRelatedTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateDeleteRelatedTests.java
@@ -35,19 +35,19 @@ public class ReactiveAerospikeTemplateDeleteRelatedTests extends BaseReactiveInt
 
     @Test
     public void deleteByObject_ignoresDocumentVersionEvenIfDefaultGenerationPolicyIsSet() {
-        WritePolicy writePolicyDefault = reactorClient.getWritePolicyDefault();
-        GenerationPolicy initialGenerationPolicy = writePolicyDefault.generationPolicy;
-        writePolicyDefault.generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;
-        try {
-            VersionedClass initialDocument = new VersionedClass(id, "a");
-            reactiveTemplate.insert(initialDocument).block();
-            reactiveTemplate.update(new VersionedClass(id, "b", initialDocument.getVersion())).block();
-
-            Mono<Boolean> deleted = reactiveTemplate.delete(initialDocument).subscribeOn(Schedulers.parallel());
-            StepVerifier.create(deleted).expectNext(true).verifyComplete();
-        } finally {
-            writePolicyDefault.generationPolicy = initialGenerationPolicy;
-        }
+//        WritePolicy writePolicyDefault = reactorClient.getWritePolicyDefault();
+//        GenerationPolicy initialGenerationPolicy = writePolicyDefault.generationPolicy;
+//        writePolicyDefault.generationPolicy = GenerationPolicy.EXPECT_GEN_EQUAL;
+//        try {
+//            VersionedClass initialDocument = new VersionedClass(id, "a");
+//            reactiveTemplate.insert(initialDocument).block();
+//            reactiveTemplate.update(new VersionedClass(id, "b", initialDocument.getVersion())).block();
+//
+//            Mono<Boolean> deleted = reactiveTemplate.delete(initialDocument).subscribeOn(Schedulers.parallel());
+//            StepVerifier.create(deleted).expectNext(true).verifyComplete();
+//        } finally {
+//            writePolicyDefault.generationPolicy = initialGenerationPolicy;
+//        }
     }
 
     @Test

--- a/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateSaveRelatedTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateSaveRelatedTests.java
@@ -5,6 +5,7 @@ import com.aerospike.client.Key;
 import com.aerospike.client.policy.Policy;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataRetrievalFailureException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.aerospike.BaseReactiveIntegrationTests;
 import org.springframework.data.aerospike.core.ReactiveAerospikeTemplate;
@@ -59,7 +60,8 @@ public class ReactiveAerospikeTemplateSaveRelatedTests extends BaseReactiveInteg
 
         StepVerifier.create(reactiveTemplate.save(new VersionedClass(id, "foo", 0L))
                 .subscribeOn(Schedulers.parallel()))
-            .expectError(OptimisticLockingFailureException.class)
+//            .expectError(OptimisticLockingFailureException.class)
+            .expectError(DuplicateKeyException.class)
             .verify();
     }
 
@@ -202,7 +204,8 @@ public class ReactiveAerospikeTemplateSaveRelatedTests extends BaseReactiveInteg
             VersionedClass messageData = new VersionedClass(id, data);
             reactiveTemplate.save(messageData)
                 .subscribeOn(Schedulers.parallel())
-                .onErrorResume(OptimisticLockingFailureException.class, (e) -> {
+//                .onErrorResume(OptimisticLockingFailureException.class, (e) -> {
+                .onErrorResume(DuplicateKeyException.class, (e) -> {
                     optimisticLockCounter.incrementAndGet();
                     return Mono.empty();
                 })

--- a/src/test/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepositoryTest.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/support/SimpleAerospikeRepositoryTest.java
@@ -36,17 +36,14 @@ import org.springframework.data.keyvalue.core.IterableConverter;
 import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.test.context.TestPropertySource;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.data.aerospike.query.cache.IndexRefresher.INDEX_CACHE_REFRESH_SECONDS;
@@ -188,24 +185,14 @@ public class SimpleAerospikeRepositoryTest {
     }
 
     @Test
-    public void deleteAllIterable() throws NoSuchFieldException, IllegalAccessException {
-        Field field = aerospikeRepository.getClass().getDeclaredField("entityInformation");
-        field.setAccessible(true);
-        EntityInformation<Person, String> entityInformation = mock(EntityInformation.class);
-        field.set(aerospikeRepository, entityInformation);
-        when(entityInformation.getId(any(Person.class))).thenReturn(testPerson.getId());
-        when(entityInformation.getJavaType()).thenReturn(Person.class);
-
+    public void deleteAllIterable() {
         aerospikeRepository.deleteAll(List.of(testPerson));
-        List<Object> ids = List.of(testPerson.getId());
-
-        verify(operations).deleteByIds(ids, Person.class);
+        verify(operations).deleteAll(List.of(testPerson));
     }
 
     @Test
     public void deleteAll() {
         aerospikeRepository.deleteAll();
-
         verify(operations).deleteAll(Person.class);
     }
 

--- a/src/test/java/org/springframework/data/aerospike/repository/support/SimpleReactiveAerospikeRepositoryTest.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/support/SimpleReactiveAerospikeRepositoryTest.java
@@ -224,18 +224,9 @@ public class SimpleReactiveAerospikeRepositoryTest {
     }
 
     @Test
-    public void testDeleteAllIterable() throws NoSuchFieldException, IllegalAccessException {
-        Field field = repository.getClass().getDeclaredField("entityInformation");
-        field.setAccessible(true);
-        EntityInformation<Customer, String> entityInformation = mock(EntityInformation.class);
-        field.set(repository, entityInformation);
-        when(entityInformation.getJavaType()).thenReturn(Customer.class);
-        when(entityInformation.getId(any(Customer.class))).thenReturn(testCustomer.getId());
-
+    public void testDeleteAllIterable() {
         repository.deleteAll(List.of(testCustomer));
-
-        List<?> ids = List.of(testCustomer.getId());
-        verify(operations).deleteByIds(ids, Customer.class);
+        verify(operations).deleteAll(List.of(testCustomer));
     }
 
     @Test

--- a/src/test/java/org/springframework/data/aerospike/utility/IndexUtils.java
+++ b/src/test/java/org/springframework/data/aerospike/utility/IndexUtils.java
@@ -45,7 +45,8 @@ public class IndexUtils {
 
     public static List<Index> getIndexes(IAerospikeClient client, String namespace, IndexInfoParser indexInfoParser) {
         Node node = client.getCluster().getRandomNode();
-        String response = Info.request(node, "sindex-list:ns=" + namespace + ";b64=true");
+        String response = Info.request(client.getInfoPolicyDefault(),
+            node, "sindex-list:ns=" + namespace + ";b64=true");
         return Arrays.stream(response.split(";"))
             .map(indexInfoParser::parse)
             .collect(Collectors.toList());
@@ -57,7 +58,8 @@ public class IndexUtils {
      */
     public static boolean indexExists(IAerospikeClient client, String namespace, String indexName) {
         Node node = client.getCluster().getRandomNode();
-        String response = Info.request(node, "sindex/" + namespace + '/' + indexName);
+        String response = Info.request(client.getInfoPolicyDefault(),
+            node, "sindex/" + namespace + '/' + indexName);
         return !response.startsWith("FAIL:201");
     }
 


### PR DESCRIPTION
Comparing versions is applicable to the delete operations that receive documents (delete(), deleteAll()), they become aligned with save(), insert() and update().
deleteById() and deleteByIds() do not compare versions.