### PR TITLE
Fix null pointer issue when typeKey is set as null

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/convert/AerospikeTypeAliasAccessor.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/AerospikeTypeAliasAccessor.java
@@ -35,6 +35,9 @@ public class AerospikeTypeAliasAccessor implements TypeAliasAccessor<Map<String,
 
     @Override
     public Alias readAliasFrom(Map<String, Object> source) {
+        if (typeKey == null) {
+            return Alias.NONE;
+        }
         return Alias.ofNullable(source.get(typeKey));
     }
 


### PR DESCRIPTION
When a custom bean of AerospikeTypeAliasAccessor is created passing null in the constructor(for skipping the typeKey to be saved in aerospike) 
eg:
```
@Bean
public AerospikeTypeAliasAccessor aerospikeTypeAliasAccessor() {
    return new AerospikeTypeAliasAccessor(null);
}
```    
While saving there is null check in writeTypeTo method to safely skip saving the typeKey if its passed as null, but in case of readAliasFrom it will throw NullPointerException, so added null check.