### PR TITLE
FMWK-348 Cleanup custom queries

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
@@ -56,7 +56,8 @@ public abstract class AbstractAerospikeDataConfiguration extends AerospikeDataCo
     public QueryEngine queryEngine(IAerospikeClient aerospikeClient,
                                    StatementBuilder statementBuilder,
                                    FilterExpressionsBuilder filterExpressionsBuilder, AerospikeSettings settings) {
-        QueryEngine queryEngine = new QueryEngine(aerospikeClient, statementBuilder, filterExpressionsBuilder);
+        QueryEngine queryEngine = new QueryEngine(aerospikeClient, statementBuilder, filterExpressionsBuilder,
+            settings.getDataSettings());
         boolean scansEnabled = settings.getDataSettings().isScansEnabled();
         log.debug("AerospikeDataSettings.scansEnabled: {}", scansEnabled);
         queryEngine.setScansEnabled(scansEnabled);

--- a/src/main/java/org/springframework/data/aerospike/config/AbstractReactiveAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractReactiveAerospikeDataConfiguration.java
@@ -68,7 +68,7 @@ public abstract class AbstractReactiveAerospikeDataConfiguration extends Aerospi
                                                  FilterExpressionsBuilder filterExpressionsBuilder,
                                                  AerospikeSettings settings) {
         ReactorQueryEngine queryEngine = new ReactorQueryEngine(aerospikeReactorClient, statementBuilder,
-            filterExpressionsBuilder);
+            filterExpressionsBuilder, settings.getDataSettings());
         boolean scansEnabled = settings.getDataSettings().isScansEnabled();
         queryEngine.setScansEnabled(scansEnabled);
         log.debug("AerospikeDataSettings.scansEnabled: {}", scansEnabled);

--- a/src/main/java/org/springframework/data/aerospike/convert/AerospikeConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/AerospikeConverter.java
@@ -43,5 +43,5 @@ public interface AerospikeConverter extends AerospikeReader<Object>, AerospikeWr
      *
      * @return the underlying {@link AerospikeDataSettings} used by the converter
      */
-    AerospikeDataSettings getAerospikeSettings();
+    AerospikeDataSettings getAerospikeDataSettings();
 }

--- a/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeConverter.java
+++ b/src/main/java/org/springframework/data/aerospike/convert/MappingAerospikeConverter.java
@@ -43,7 +43,7 @@ public class MappingAerospikeConverter implements InitializingBean, AerospikeCon
     @Getter
     private final GenericConversionService conversionService;
     @Getter
-    private final AerospikeDataSettings aerospikeSettings;
+    private final AerospikeDataSettings aerospikeDataSettings;
     private final MappingAerospikeReadConverter readConverter;
     private final MappingAerospikeWriteConverter writeConverter;
 
@@ -55,7 +55,7 @@ public class MappingAerospikeConverter implements InitializingBean, AerospikeCon
                                      AerospikeDataSettings settings) {
         this.conversions = conversions;
         this.conversionService = new DefaultConversionService();
-        this.aerospikeSettings = settings;
+        this.aerospikeDataSettings = settings;
 
         EntityInstantiators entityInstantiators = new EntityInstantiators();
         TypeMapper<Map<String, Object>> typeMapper = new DefaultTypeMapper<>(aerospikeTypeAliasAccessor,

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -173,7 +173,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
     }
 
     private <T> void applyBufferedBatchWrite(Iterable<T> documents, String setName, OperationType operationType) {
-        int batchSize = converter.getAerospikeSettings().getBatchWriteSize();
+        int batchSize = converter.getAerospikeDataSettings().getBatchWriteSize();
         List<T> docsList = new ArrayList<>();
 
         for (T doc : documents) {
@@ -456,7 +456,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
     public <T> void deleteAll(Iterable<T> documents) {
         String setName = getSetName(documents.iterator().next());
 
-        int batchSize = converter.getAerospikeSettings().getBatchWriteSize();
+        int batchSize = converter.getAerospikeDataSettings().getBatchWriteSize();
         List<Object> documentsList = new ArrayList<>();
         for (Object document : documents) {
             if (batchWriteSizeMatch(batchSize, documentsList.size())) {
@@ -490,7 +490,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
         Assert.notNull(setName, "Set name must not be null!");
         validateForBatchWrite(ids, "IDs");
 
-        int batchSize = converter.getAerospikeSettings().getBatchWriteSize();
+        int batchSize = converter.getAerospikeDataSettings().getBatchWriteSize();
         List<Object> idsList = new ArrayList<>();
         for (Object id : ids) {
             if (batchWriteSizeMatch(batchSize, idsList.size())) {
@@ -884,7 +884,7 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
         Assert.notNull(entityClass, "Entity class must not be null!");
         Assert.notNull(setName, "Set name must not be null!");
 
-        int batchSize = converter.getAerospikeSettings().getBatchWriteSize();
+        int batchSize = converter.getAerospikeDataSettings().getBatchWriteSize();
         List<Object> idsList = new ArrayList<>();
         List<S> result = new ArrayList<>();
 

--- a/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/BaseAerospikeTemplate.java
@@ -314,7 +314,7 @@ abstract class BaseAerospikeTemplate {
         Assert.notNull(setName, "Set name must not be null!");
         Key key;
         // choosing whether tp preserve id type based on the configuration
-        if (converter.getAerospikeSettings().isKeepOriginalKeyTypes()) {
+        if (converter.getAerospikeDataSettings().isKeepOriginalKeyTypes()) {
             if (id instanceof Byte || id instanceof Short || id instanceof Integer || id instanceof Long) {
                 key = new Key(this.namespace, setName, convertIfNecessary(((Number) id).longValue(), Long.class));
             } else if (id instanceof Character) {

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -160,7 +160,7 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
 
     private <T> Flux<T> applyBufferedBatchWrite(Iterable<? extends T> documents, String setName,
                                                 OperationType operationType) {
-        int batchSize = converter.getAerospikeSettings().getBatchWriteSize();
+        int batchSize = converter.getAerospikeDataSettings().getBatchWriteSize();
         List<T> docsList = new ArrayList<>();
         Flux<T> result = Flux.empty();
 
@@ -477,7 +477,7 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
         Assert.notNull(setName, "Set name must not be null!");
         validateForBatchWrite(ids, "IDs");
 
-        int batchSize = converter.getAerospikeSettings().getBatchWriteSize();
+        int batchSize = converter.getAerospikeDataSettings().getBatchWriteSize();
         List<Object> idsList = new ArrayList<>();
         Flux<Void> result = Flux.empty();
         for (Object id : ids) {
@@ -786,7 +786,7 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
         Assert.notNull(targetClass, "Class must not be null!");
         Assert.notNull(setName, "Set name must not be null!");
 
-        int batchSize = converter.getAerospikeSettings().getBatchWriteSize();
+        int batchSize = converter.getAerospikeDataSettings().getBatchWriteSize();
         List<Object> idsList = new ArrayList<>();
         Flux<T> result = Flux.empty();
 

--- a/src/main/java/org/springframework/data/aerospike/query/FilterOperation.java
+++ b/src/main/java/org/springframework/data/aerospike/query/FilterOperation.java
@@ -26,7 +26,7 @@ import com.aerospike.client.exp.MapExp;
 import com.aerospike.client.query.Filter;
 import com.aerospike.client.query.IndexCollectionType;
 import com.aerospike.client.query.RegexFlag;
-import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
+import org.springframework.data.aerospike.config.AerospikeDataSettings;
 import org.springframework.data.aerospike.query.qualifier.Qualifier;
 import org.springframework.data.aerospike.query.qualifier.QualifierKey;
 import org.springframework.data.aerospike.repository.query.CriteriaDefinition;
@@ -56,7 +56,6 @@ import static org.springframework.data.aerospike.util.FilterOperationRegexpBuild
 import static org.springframework.data.aerospike.util.FilterOperationRegexpBuilder.getStringEquals;
 
 public enum FilterOperation {
-
     AND {
         @Override
         public Exp filterExp(Map<QualifierKey, Object> qualifierMap) {
@@ -462,9 +461,8 @@ public enum FilterOperation {
          */
         @Override
         public Filter sIndexFilter(Map<QualifierKey, Object> qualifierMap) {
-            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_EQ_BY_KEY secondary index filter: dotPath has not been set");
-            final boolean useCtx = dotPathArr.length > 2;
+            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
+            final boolean useCtx = dotPathArr != null && dotPathArr.length > 2;
 
             return switch (getValue(qualifierMap).getType()) {
                 case STRING -> {
@@ -518,9 +516,8 @@ public enum FilterOperation {
                 return null;
             }
 
-            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_GT_BY_KEY secondary index filter: dotPath has not been set");
-            if (dotPathArr.length > 2) {
+            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
+            if (dotPathArr != null && dotPathArr.length > 2) {
                 return null; // currently not supported
             } else {
                 return Filter.range(getField(qualifierMap), IndexCollectionType.MAPVALUES,
@@ -544,9 +541,8 @@ public enum FilterOperation {
                 return null;
             }
 
-            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_GTEQ_BY_KEY secondary index filter: dotPath has not been set");
-            if (dotPathArr.length > 2) {
+            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
+            if (dotPathArr != null && dotPathArr.length > 2) {
                 return null; // currently not supported
             } else {
                 return Filter.range(getField(qualifierMap), IndexCollectionType.MAPVALUES,
@@ -571,9 +567,8 @@ public enum FilterOperation {
                 return null;
             }
 
-            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_LT_BY_KEY secondary index filter: dotPath has not been set");
-            if (dotPathArr.length > 2) {
+            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
+            if (dotPathArr != null && dotPathArr.length > 2) {
                 return null; // currently not supported
             } else {
                 return Filter.range(getField(qualifierMap), IndexCollectionType.MAPVALUES, Long.MIN_VALUE,
@@ -596,9 +591,8 @@ public enum FilterOperation {
                 return null;
             }
 
-            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_LTEQ_BY_KEY secondary index filter: dotPath has not been set");
-            if (dotPathArr.length > 2) {
+            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
+            if (dotPathArr != null && dotPathArr.length > 2) {
                 return null; // currently not supported
             } else {
                 return Filter.range(getField(qualifierMap), IndexCollectionType.MAPVALUES, Long.MIN_VALUE,
@@ -609,8 +603,7 @@ public enum FilterOperation {
     MAP_VAL_BETWEEN_BY_KEY {
         @Override
         public Exp filterExp(Map<QualifierKey, Object> qualifierMap) {
-            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_BETWEEN_BY_KEY filter expression: dotPath has not been set");
+            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
             Exp lowerLimit;
             Exp upperLimit;
             Exp.Type type;
@@ -648,7 +641,7 @@ public enum FilterOperation {
                                               Exp lowerLimit,
                                               Exp upperLimit) {
             Exp mapExp;
-            if (dotPathArr.length > 2) {
+            if (dotPathArr != null && dotPathArr.length > 2) {
                 mapExp = MapExp.getByKey(MapReturnType.VALUE, type, Exp.val(getKey(qualifierMap).toString()),
                     Exp.mapBin(getField(qualifierMap)), dotPathToCtxMapKeys(dotPathArr));
             } else {
@@ -671,9 +664,8 @@ public enum FilterOperation {
                 return null;
             }
 
-            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_BETWEEN_BY_KEY secondary index filter: dotPath has not been set");
-            if (dotPathArr.length > 2) {
+            String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
+            if (dotPathArr != null && dotPathArr.length > 2) {
                 return null; // currently not supported
             } else {
                 return Filter.range(getField(qualifierMap), IndexCollectionType.MAPVALUES,
@@ -792,9 +784,9 @@ public enum FilterOperation {
     MAP_VAL_IS_NOT_NULL_BY_KEY {
         @Override
         public Exp filterExp(Map<QualifierKey, Object> qualifierMap) {
-            String[] dotPathArray = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_IS_NULL_BY_KEY: dotPath was not set");
-            if (dotPathArray.length > 1) {
+            String[] dotPathArray = getDotPathArray(getDotPath(qualifierMap)
+            );
+            if (dotPathArray != null && dotPathArray.length > 1) {
                 // in case it is a field of an object set to null the key does not get added to a Map,
                 // so it is enough to look for Maps with the given key
                 return mapKeysContain(qualifierMap);
@@ -813,9 +805,9 @@ public enum FilterOperation {
     MAP_VAL_IS_NULL_BY_KEY {
         @Override
         public Exp filterExp(Map<QualifierKey, Object> qualifierMap) {
-            String[] dotPathArray = getDotPathArray(getDotPath(qualifierMap),
-                "MAP_VAL_IS_NULL_BY_KEY: dotPath was not set");
-            if (dotPathArray.length > 1) {
+            String[] dotPathArray = getDotPathArray(getDotPath(qualifierMap)
+            );
+            if (dotPathArray != null && dotPathArray.length > 1) {
                 // in case it is a field of an object set to null the key does not get added to a Map,
                 // so it is enough to look for Maps without the given key
                 return mapKeysNotContain(qualifierMap);
@@ -1413,8 +1405,8 @@ public enum FilterOperation {
 
     private static Exp getFilterExpMapValOrFail(Map<QualifierKey, Object> qualifierMap, BinaryOperator<Exp> operator,
                                                 String opName) {
-        String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-            opName + " filter expression: dotPath has not been set");
+        String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap)
+        );
 
         return switch (getValue(qualifierMap).getType()) {
             case INTEGER -> operator.apply(getMapExp(qualifierMap, dotPathArr, Exp.Type.INT),
@@ -1432,7 +1424,7 @@ public enum FilterOperation {
 
     private static Exp getMapExp(Map<QualifierKey, Object> qualifierMap, String[] dotPathArr, Exp.Type expType) {
         Exp mapKeyExp = getMapKeyExp(getKey(qualifierMap).getObject(), keepOriginalKeyTypes(qualifierMap));
-        if (dotPathArr.length > 2) {
+        if (dotPathArr != null && dotPathArr.length > 2) {
             return MapExp.getByKey(MapReturnType.VALUE, expType, mapKeyExp,
                 Exp.mapBin(getField(qualifierMap)), dotPathToCtxMapKeys(dotPathArr));
         } else {
@@ -1463,8 +1455,10 @@ public enum FilterOperation {
     }
 
     private static boolean keepOriginalKeyTypes(Map<QualifierKey, Object> qualifierMap) {
-        return ((MappingAerospikeConverter) qualifierMap.get(CONVERTER))
-            .getAerospikeSettings().isKeepOriginalKeyTypes();
+        Object dataSettings = qualifierMap.get(DATA_SETTINGS);
+        if (dataSettings == null) throw new IllegalStateException("Expecting AerospikeDataSettings in qualifier map " +
+            "with the key " + DATA_SETTINGS);
+        return ((AerospikeDataSettings) dataSettings).isKeepOriginalKeyTypes();
     }
 
     private static Exp getFilterExpMapValEqOrFail(Map<QualifierKey, Object> qualifierMap,
@@ -1479,9 +1473,8 @@ public enum FilterOperation {
 
     private static Exp getMapValEqOrFail(Map<QualifierKey, Object> qualifierMap, BinaryOperator<Exp> operator,
                                          String opName) {
-        String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap),
-            opName + " filter expression: dotPath has not been set");
-        final boolean useCtx = dotPathArr.length > 2;
+        String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
+        final boolean useCtx = dotPathArr != null && dotPathArr.length > 2;
 
         // boolean values are read as BoolIntValue (INTEGER ParticleType) if Value.UseBoolBin == false
         // so converting to BooleanValue to process correctly
@@ -1536,7 +1529,7 @@ public enum FilterOperation {
         return operator.apply(binExp.apply(field), exp);
     }
 
-    private static String[] getDotPathArray(List<String> dotPathList, String errMsg) {
+    private static String[] getDotPathArray(List<String> dotPathList) {
         if (dotPathList != null && !dotPathList.isEmpty()) {
             // the first element of dotPath is part.getProperty().toDotPath()
             // the second element of dotPath, if present, is a value
@@ -1544,9 +1537,8 @@ public enum FilterOperation {
                 : Stream.of(dotPathList.get(1));
             return Stream.concat(Arrays.stream(dotPathList.get(0).split("\\.")), valueStream)
                 .toArray(String[]::new);
-        } else {
-            throw new IllegalStateException(errMsg);
         }
+        return null;
     }
 
     private static CTX[] dotPathToCtxMapKeys(String[] dotPathArray) {

--- a/src/main/java/org/springframework/data/aerospike/query/FilterOperation.java
+++ b/src/main/java/org/springframework/data/aerospike/query/FilterOperation.java
@@ -784,8 +784,7 @@ public enum FilterOperation {
     MAP_VAL_IS_NOT_NULL_BY_KEY {
         @Override
         public Exp filterExp(Map<QualifierKey, Object> qualifierMap) {
-            String[] dotPathArray = getDotPathArray(getDotPath(qualifierMap)
-            );
+            String[] dotPathArray = getDotPathArray(getDotPath(qualifierMap));
             if (dotPathArray != null && dotPathArray.length > 1) {
                 // in case it is a field of an object set to null the key does not get added to a Map,
                 // so it is enough to look for Maps with the given key
@@ -805,8 +804,7 @@ public enum FilterOperation {
     MAP_VAL_IS_NULL_BY_KEY {
         @Override
         public Exp filterExp(Map<QualifierKey, Object> qualifierMap) {
-            String[] dotPathArray = getDotPathArray(getDotPath(qualifierMap)
-            );
+            String[] dotPathArray = getDotPathArray(getDotPath(qualifierMap));
             if (dotPathArray != null && dotPathArray.length > 1) {
                 // in case it is a field of an object set to null the key does not get added to a Map,
                 // so it is enough to look for Maps without the given key
@@ -1405,8 +1403,7 @@ public enum FilterOperation {
 
     private static Exp getFilterExpMapValOrFail(Map<QualifierKey, Object> qualifierMap, BinaryOperator<Exp> operator,
                                                 String opName) {
-        String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap)
-        );
+        String[] dotPathArr = getDotPathArray(getDotPath(qualifierMap));
 
         return switch (getValue(qualifierMap).getType()) {
             case INTEGER -> operator.apply(getMapExp(qualifierMap, dotPathArr, Exp.Type.INT),

--- a/src/main/java/org/springframework/data/aerospike/query/QueryEngine.java
+++ b/src/main/java/org/springframework/data/aerospike/query/QueryEngine.java
@@ -26,6 +26,7 @@ import com.aerospike.client.query.RecordSet;
 import com.aerospike.client.query.Statement;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.aerospike.config.AerospikeDataSettings;
 import org.springframework.data.aerospike.query.qualifier.Qualifier;
 import org.springframework.data.aerospike.repository.query.Query;
 import org.springframework.lang.Nullable;
@@ -48,6 +49,7 @@ public class QueryEngine {
     private final StatementBuilder statementBuilder;
     @Getter
     private final FilterExpressionsBuilder filterExpressionsBuilder;
+    private final AerospikeDataSettings dataSettings;
     /**
      * Scans can potentially slow down Aerospike server, so we are disabling them by default. If you still need to use
      * scans, set this property to true.
@@ -59,10 +61,11 @@ public class QueryEngine {
     private long queryMaxRecords;
 
     public QueryEngine(IAerospikeClient client, StatementBuilder statementBuilder,
-                       FilterExpressionsBuilder filterExpressionsBuilder) {
+                       FilterExpressionsBuilder filterExpressionsBuilder, AerospikeDataSettings dataSettings) {
         this.client = client;
         this.statementBuilder = statementBuilder;
         this.filterExpressionsBuilder = filterExpressionsBuilder;
+        this.dataSettings = dataSettings;
     }
 
     /**
@@ -106,6 +109,10 @@ public class QueryEngine {
         /*
          *  query with filters
          */
+        if (query != null) {
+            // dataSettings provided to be used in FilterOperation
+            query.getCriteriaObject().setDataSettings(dataSettings);
+        }
         Statement statement = statementBuilder.build(namespace, set, query, binNames);
         statement.setMaxRecords(queryMaxRecords);
         QueryPolicy localQueryPolicy = getQueryPolicy(query, true);

--- a/src/main/java/org/springframework/data/aerospike/query/ReactorQueryEngine.java
+++ b/src/main/java/org/springframework/data/aerospike/query/ReactorQueryEngine.java
@@ -24,6 +24,7 @@ import com.aerospike.client.query.Statement;
 import com.aerospike.client.reactor.IAerospikeReactorClient;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.aerospike.config.AerospikeDataSettings;
 import org.springframework.data.aerospike.query.qualifier.Qualifier;
 import org.springframework.data.aerospike.repository.query.Query;
 import org.springframework.lang.Nullable;
@@ -46,6 +47,7 @@ public class ReactorQueryEngine {
     private final StatementBuilder statementBuilder;
     @Getter
     private final FilterExpressionsBuilder filterExpressionsBuilder;
+    private final AerospikeDataSettings dataSettings;
     /**
      * Scans can potentially slow down Aerospike server, so we are disabling them by default. If you still need to use
      * scans, set this property to true.
@@ -57,10 +59,11 @@ public class ReactorQueryEngine {
     private long queryMaxRecords;
 
     public ReactorQueryEngine(IAerospikeReactorClient client, StatementBuilder statementBuilder,
-                              FilterExpressionsBuilder filterExpressionsBuilder) {
+                              FilterExpressionsBuilder filterExpressionsBuilder, AerospikeDataSettings dataSettings) {
         this.client = client;
         this.statementBuilder = statementBuilder;
         this.filterExpressionsBuilder = filterExpressionsBuilder;
+        this.dataSettings = dataSettings;
     }
 
     /**
@@ -99,6 +102,9 @@ public class ReactorQueryEngine {
         /*
          *  query with filters
          */
+        if (query != null) {
+            query.getCriteriaObject().setDataSettings(dataSettings);
+        }
         Statement statement = statementBuilder.build(namespace, set, query, binNames);
         statement.setMaxRecords(queryMaxRecords);
         QueryPolicy localQueryPolicy = getQueryPolicy(query, true);

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/BaseQualifierBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/BaseQualifierBuilder.java
@@ -1,5 +1,11 @@
 package org.springframework.data.aerospike.query.qualifier;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.aerospike.config.AerospikeDataConfigurationSupport;
+import org.springframework.data.aerospike.config.AerospikeSettings;
+import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 import org.springframework.data.aerospike.query.FilterOperation;
 
 import java.util.Collections;
@@ -19,32 +25,32 @@ abstract class BaseQualifierBuilder<T extends BaseQualifierBuilder<?>> implement
     protected final Map<QualifierKey, Object> map = new HashMap<>();
 
     public FilterOperation getFilterOperation() {
-        return (FilterOperation) this.map.get(OPERATION);
+        return (FilterOperation) map.get(OPERATION);
     }
 
     public T setFilterOperation(FilterOperation filterOperation) {
-        this.map.put(OPERATION, filterOperation);
+        map.put(OPERATION, filterOperation);
         return (T) this;
     }
 
     public String getField() {
-        return (String) this.map.get(FIELD);
+        return (String) map.get(FIELD);
     }
 
     public boolean hasKey() {
-        return this.map.get(KEY) != null;
+        return map.get(KEY) != null;
     }
 
     public boolean hasValue() {
-        return this.map.get(VALUE) != null;
+        return map.get(VALUE) != null;
     }
 
     public boolean hasSecondValue() {
-        return this.map.get(SECOND_VALUE) != null;
+        return map.get(SECOND_VALUE) != null;
     }
 
     public boolean hasDotPath() {
-        return this.map.get(DOT_PATH) != null;
+        return map.get(DOT_PATH) != null;
     }
 
     public Qualifier build() {
@@ -53,7 +59,7 @@ abstract class BaseQualifierBuilder<T extends BaseQualifierBuilder<?>> implement
     }
 
     public Map<QualifierKey, Object> getMap() {
-        return Collections.unmodifiableMap(this.map);
+        return Collections.unmodifiableMap(map);
     }
 
     protected void validate() {

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/Qualifier.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/Qualifier.java
@@ -20,6 +20,7 @@ import com.aerospike.client.Value;
 import com.aerospike.client.command.ParticleType;
 import com.aerospike.client.exp.Exp;
 import com.aerospike.client.query.Filter;
+import org.springframework.data.aerospike.config.AerospikeDataSettings;
 import org.springframework.data.aerospike.query.FilterOperation;
 import org.springframework.data.aerospike.repository.query.CriteriaDefinition;
 import org.springframework.util.StringUtils;
@@ -100,6 +101,10 @@ public class Qualifier implements CriteriaDefinition, Map<QualifierKey, Object>,
 
     public Boolean queryAsFilter() {
         return internalMap.containsKey(AS_FILTER) && (Boolean) internalMap.get(AS_FILTER);
+    }
+
+    public void setDataSettings(AerospikeDataSettings dataSettings) {
+        internalMap.put(DATA_SETTINGS, dataSettings);
     }
 
     public boolean hasQualifiers() {

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/QualifierBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/QualifierBuilder.java
@@ -1,7 +1,6 @@
 package org.springframework.data.aerospike.query.qualifier;
 
 import com.aerospike.client.Value;
-import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 
 import java.util.List;
 
@@ -33,7 +32,7 @@ public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
     /**
      * Set Map key.
      * <p>
-     * Use one of Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
+     * Use one of the Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
      * key into a {@link Value} object.
      */
     public QualifierBuilder setKey(Value key) {
@@ -44,7 +43,7 @@ public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
     /**
      * Set value.
      * <p>
-     * Use one of Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
+     * Use one of the Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
      * value into a {@link Value} object.
      */
     public QualifierBuilder setValue(Value value) {
@@ -55,7 +54,7 @@ public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
     /**
      * Set second value.
      * <p>
-     * Use one of Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
+     * Use one of the Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
      * second value into a {@link Value} object.
      */
     public QualifierBuilder setSecondValue(Value secondValue) {
@@ -64,7 +63,7 @@ public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
     }
 
     /**
-     * Required only for a nested value query (e.g. find by a field of a POJO).
+     * Required only for a nested value query (e.g. find by a POJO field).
      */
     public QualifierBuilder setDotPath(List<String> dotPath) {
         this.map.put(DOT_PATH, dotPath);

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/QualifierBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/QualifierBuilder.java
@@ -5,7 +5,6 @@ import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
 
 import java.util.List;
 
-import static org.springframework.data.aerospike.query.qualifier.QualifierKey.CONVERTER;
 import static org.springframework.data.aerospike.query.qualifier.QualifierKey.DOT_PATH;
 import static org.springframework.data.aerospike.query.qualifier.QualifierKey.FIELD;
 import static org.springframework.data.aerospike.query.qualifier.QualifierKey.IGNORE_CASE;
@@ -23,33 +22,52 @@ public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
         return this;
     }
 
+    /**
+     * Set bin name.
+     */
     public QualifierBuilder setField(String field) {
         this.map.put(FIELD, field);
         return this;
     }
 
+    /**
+     * Set Map key.
+     * <p>
+     * Use one of Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
+     * key into a {@link Value} object.
+     */
     public QualifierBuilder setKey(Value key) {
         this.map.put(KEY, key);
         return this;
     }
 
+    /**
+     * Set value.
+     * <p>
+     * Use one of Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
+     * value into a {@link Value} object.
+     */
     public QualifierBuilder setValue(Value value) {
         this.map.put(VALUE, value);
         return this;
     }
 
+    /**
+     * Set second value.
+     * <p>
+     * Use one of Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
+     * second value into a {@link Value} object.
+     */
     public QualifierBuilder setSecondValue(Value secondValue) {
         this.map.put(SECOND_VALUE, secondValue);
         return this;
     }
 
+    /**
+     * Required only for a nested value query (e.g. find by a field of a POJO).
+     */
     public QualifierBuilder setDotPath(List<String> dotPath) {
         this.map.put(DOT_PATH, dotPath);
-        return this;
-    }
-
-    public QualifierBuilder setConverter(MappingAerospikeConverter converter) {
-        this.map.put(CONVERTER, converter);
         return this;
     }
 }

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/QualifierKey.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/QualifierKey.java
@@ -14,7 +14,7 @@ public enum QualifierKey {
     VALUE,
     SECOND_VALUE,
     DOT_PATH,
-    CONVERTER,
+    DATA_SETTINGS,
     QUALIFIERS,
     OPERATION,
     DIGEST_KEY,

--- a/src/main/java/org/springframework/data/aerospike/repository/query/AerospikeQueryCreatorUtils.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/query/AerospikeQueryCreatorUtils.java
@@ -24,12 +24,11 @@ import static org.springframework.util.ClassUtils.isAssignableValue;
 
 public class AerospikeQueryCreatorUtils {
 
-    protected static Qualifier setQualifier(MappingAerospikeConverter converter, QualifierBuilder qb,
+    protected static Qualifier setQualifier(QualifierBuilder qb,
                                             String fieldName, FilterOperation op, Part part, List<String> dotPath) {
         qb.setField(fieldName)
             .setFilterOperation(op)
-            .setIgnoreCase(ignoreCaseToBoolean(part))
-            .setConverter(converter);
+            .setIgnoreCase(ignoreCaseToBoolean(part));
         if (dotPath != null && !qb.hasDotPath()) qb.setDotPath(dotPath);
 
         return qb.build();
@@ -82,13 +81,13 @@ public class AerospikeQueryCreatorUtils {
             qualifiers = new Qualifier[params.size() / 2]; // keys/values qty must be even
             for (int i = 0, j = 0; i < params.size(); i += 2, j++) {
                 setQbValuesForMapByKey(qb, params.get(i), params.get(i + 1));
-                qualifiers[j] = setQualifier(converter, qb, fieldName, op, part, dotPath);
+                qualifiers[j] = setQualifier(qb, fieldName, op, part, dotPath);
             }
         }
         qualifiers = new Qualifier[params.size()];
         for (int i = 0; i < params.size(); i++) {
             setQbValuesForMapByKey(qb, params.get(i), params.get(i));
-            qualifiers[i] = setQualifier(converter, qb, fieldName, op, part, dotPath);
+            qualifiers[i] = setQualifier(qb, fieldName, op, part, dotPath);
         }
 
         return Qualifier.and(qualifiers);

--- a/src/main/java/org/springframework/data/aerospike/repository/query/CollectionQueryCreator.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/query/CollectionQueryCreator.java
@@ -127,7 +127,7 @@ public class CollectionQueryCreator implements IAerospikeQueryCreator {
         }
         setQualifierBuilderValue(qb, queryParameters.get(0));
 
-        return setQualifier(converter, qb, fieldName, op, part, null);
+        return setQualifier(qb, fieldName, op, part, null);
     }
 
     private FilterOperation getCorrespondingListFilterOperationOrFail(FilterOperation op) {

--- a/src/main/java/org/springframework/data/aerospike/repository/query/MapQueryCreator.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/query/MapQueryCreator.java
@@ -172,14 +172,14 @@ public class MapQueryCreator implements IAerospikeQueryCreator {
 
     @Override
     public Qualifier process() {
-        Qualifier qualifier = null;
+        Qualifier qualifier;
         QualifierBuilder qb = Qualifier.builder();
         int paramsSize = queryParameters.size();
 
         if (filterOperation == BETWEEN || filterOperation == IN || filterOperation == NOT_IN) {
             setQualifierBuilderValue(qb, queryParameters.get(0));
             if (queryParameters.size() >= 2) setQualifierBuilderSecondValue(qb, queryParameters.get(1));
-            qualifier = setQualifier(converter, qb, fieldName, filterOperation, part, null);
+            qualifier = setQualifier(qb, fieldName, filterOperation, part, null);
             return qualifier;
         }
 
@@ -187,7 +187,7 @@ public class MapQueryCreator implements IAerospikeQueryCreator {
             qualifier = processMapTwoParams(part, queryParameters, filterOperation, fieldName);
         } else if (queryParameters.size() < 2) {
             setQualifierBuilderValue(qb, queryParameters.get(0));
-            qualifier = setQualifier(converter, qb, fieldName, filterOperation, part, null);
+            qualifier = setQualifier(qb, fieldName, filterOperation, part, null);
         } else { // multiple parameters
             qualifier = processMapMultipleParams(part, queryParameters, filterOperation, fieldName);
         }
@@ -228,7 +228,7 @@ public class MapQueryCreator implements IAerospikeQueryCreator {
                 default -> throw new UnsupportedOperationException("Unsupported parameter: " + queryCriterion);
             }
         }
-        return setQualifier(converter, qb, fieldName, op, part, null);
+        return setQualifier(qb, fieldName, op, part, null);
     }
 
     private Qualifier processMapOtherThanContaining(Part part, List<Object> queryParameters, FilterOperation op,
@@ -243,7 +243,7 @@ public class MapQueryCreator implements IAerospikeQueryCreator {
 
         setQualifierBuilderKey(qb, queryParameters.get(0));
         setQualifierBuilderValue(qb, queryParameters.get(1));
-        return setQualifier(converter, qb, fieldName, op, part, dotPath);
+        return setQualifier(qb, fieldName, op, part, dotPath);
     }
 
     private Qualifier processMapMultipleParams(Part part, List<Object> params, FilterOperation op, String fieldName) {
@@ -283,7 +283,7 @@ public class MapQueryCreator implements IAerospikeQueryCreator {
 
         if (op == MAP_VAL_CONTAINING_BY_KEY || op == MAP_VAL_NOT_CONTAINING_BY_KEY
             || op == MAP_VAL_EQ_BY_KEY || op == MAP_VAL_NOTEQ_BY_KEY) {
-            return setQualifier(converter, qb, fieldName, op, part, dotPath);
+            return setQualifier(qb, fieldName, op, part, dotPath);
         } else {
             return qualifierAndConcatenated(converter, params, qb, part, fieldName, op, dotPath);
         }

--- a/src/main/java/org/springframework/data/aerospike/repository/query/PojoQueryCreator.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/query/PojoQueryCreator.java
@@ -115,6 +115,6 @@ public class PojoQueryCreator implements IAerospikeQueryCreator {
             }
         }
 
-        return setQualifier(converter, qb, fieldName, op, part, dotPath);
+        return setQualifier(qb, fieldName, op, part, dotPath);
     }
 }

--- a/src/main/java/org/springframework/data/aerospike/repository/query/SimplePropertyQueryCreator.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/query/SimplePropertyQueryCreator.java
@@ -138,7 +138,7 @@ public class SimplePropertyQueryCreator implements IAerospikeQueryCreator {
             setQualifierBuilderValue(qb, queryParameters.get(0));
         }
 
-        return setQualifier(converter, qb, fieldName, op, part, dotPath);
+        return setQualifier(qb, fieldName, op, part, dotPath);
     }
 
     private boolean convertPartTypeToBoolean(Part.Type type) {

--- a/src/test/java/org/springframework/data/aerospike/convert/AerospikeReadDataIntegrationTests.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/AerospikeReadDataIntegrationTests.java
@@ -51,7 +51,7 @@ class AerospikeReadDataIntegrationTests extends BaseBlockingIntegrationTests {
         // we can read the record into a User document because its class is given
         List<User> users = template.findAll(User.class).toList();
         User user;
-        if (template.getAerospikeConverter().getAerospikeSettings().isKeepOriginalKeyTypes()) {
+        if (template.getAerospikeConverter().getAerospikeDataSettings().isKeepOriginalKeyTypes()) {
             // we need isKeepOriginalKeyTypes == true because id is of type long, otherwise findById() returns null
             // isKeepOriginalKeyTypes parameter would be unimportant if id were of type String
             user = template.findById(longId, User.class);
@@ -85,7 +85,7 @@ class AerospikeReadDataIntegrationTests extends BaseBlockingIntegrationTests {
         // we can read the record into a Document because its class is given
         List<Document> users = template.findAll(Document.class).toList();
         Document document;
-        if (template.getAerospikeConverter().getAerospikeSettings().isKeepOriginalKeyTypes()) {
+        if (template.getAerospikeConverter().getAerospikeDataSettings().isKeepOriginalKeyTypes()) {
             // original id has type long
             document = template.findById(longId, Document.class);
             assertThat(users.get(0).getId()).isEqualTo(document.getId());

--- a/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTests.java
+++ b/src/test/java/org/springframework/data/aerospike/convert/MappingAerospikeConverterTypesTests.java
@@ -789,14 +789,14 @@ public class MappingAerospikeConverterTypesTests extends BaseMappingAerospikeCon
 
         aerospikeConverter.write(object, forWrite);
 
-        KeyAssert.assertThat(forWrite.getKey()).consistsOf(aerospikeConverter.getAerospikeSettings(), NAMESPACE,
+        KeyAssert.assertThat(forWrite.getKey()).consistsOf(aerospikeConverter.getAerospikeDataSettings(), NAMESPACE,
             expectedSet, expectedUserKey);
 
         for (Bin expectedBin : expectedBins) {
             if (expectedBin.value.getType() == ParticleType.MAP) {
                 // Compare Maps
                 assertThat(
-                    compareMaps(aerospikeConverter.getAerospikeSettings(), expectedBin,
+                    compareMaps(aerospikeConverter.getAerospikeDataSettings(), expectedBin,
                         forWrite.getBins().stream().filter(bin -> bin.name.equals(expectedBin.name))
                             .findFirst().orElse(null))).isTrue();
             } else {
@@ -833,7 +833,7 @@ public class MappingAerospikeConverterTypesTests extends BaseMappingAerospikeCon
 
         aerospikeConverter.write(object, forWrite);
 
-        KeyAssert.assertThat(forWrite.getKey()).consistsOf(aerospikeConverter.getAerospikeSettings(), NAMESPACE,
+        KeyAssert.assertThat(forWrite.getKey()).consistsOf(aerospikeConverter.getAerospikeDataSettings(), NAMESPACE,
             expectedSet, expectedUserKey);
         assertThat(forWrite.getBins()).containsOnly(expectedBins);
 

--- a/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateFindByIdTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/AerospikeTemplateFindByIdTests.java
@@ -160,7 +160,7 @@ public class AerospikeTemplateFindByIdTests extends BaseBlockingIntegrationTests
 
     @Test
     public void findById_shouldReadClassWithNumericKeyMapWrittenByTemplate() {
-        if (template.getAerospikeConverter().getAerospikeSettings().isKeepOriginalKeyTypes()) {
+        if (template.getAerospikeConverter().getAerospikeDataSettings().isKeepOriginalKeyTypes()) {
             int intKey = 1;
             double doubleKey = 100.25;
             String value = "String value";
@@ -181,7 +181,7 @@ public class AerospikeTemplateFindByIdTests extends BaseBlockingIntegrationTests
 
     @Test
     public void findById_shouldReadClassWithNumericKeyMap() {
-        if (template.getAerospikeConverter().getAerospikeSettings().isKeepOriginalKeyTypes()) {
+        if (template.getAerospikeConverter().getAerospikeDataSettings().isKeepOriginalKeyTypes()) {
             int intKey = 1;
             double doubleKey = 100.25;
             String value = "String value";
@@ -206,7 +206,7 @@ public class AerospikeTemplateFindByIdTests extends BaseBlockingIntegrationTests
 
     @Test
     public void findById_shouldReadClassWithByteArrayId() {
-        if (template.getAerospikeConverter().getAerospikeSettings().isKeepOriginalKeyTypes()) {
+        if (template.getAerospikeConverter().getAerospikeDataSettings().isKeepOriginalKeyTypes()) {
             long longId = 10L;
             SampleClasses.DocumentWithLongId document = SampleClasses.DocumentWithLongId.builder().id(longId).build();
             template.save(document);

--- a/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateFindByIdTests.java
+++ b/src/test/java/org/springframework/data/aerospike/core/reactive/ReactiveAerospikeTemplateFindByIdTests.java
@@ -106,7 +106,7 @@ public class ReactiveAerospikeTemplateFindByIdTests extends BaseReactiveIntegrat
 
     @Test
     public void findById_shouldReadClassWithNonStringId() {
-        if (reactiveTemplate.getAerospikeConverter().getAerospikeSettings().isKeepOriginalKeyTypes()) {
+        if (reactiveTemplate.getAerospikeConverter().getAerospikeDataSettings().isKeepOriginalKeyTypes()) {
             long longId = 10L;
             SampleClasses.DocumentWithLongId document = SampleClasses.DocumentWithLongId.builder().id(longId).build();
             reactiveTemplate.save(document).block();

--- a/src/test/java/org/springframework/data/aerospike/repository/query/blocking/noindex/findBy/CustomQueriesTests.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/query/blocking/noindex/findBy/CustomQueriesTests.java
@@ -215,7 +215,7 @@ public class CustomQueriesTests extends PersonRepositoryQueryTests {
         assertThatThrownBy(() -> repository.findUsingQuery(new Query(Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.LTEQ)
-            .setValueAsObj(Value.get(1))
+            .setValueAsObj(1)
             .build())))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("LTEQ: value1 is expected to be set as Long");
@@ -264,19 +264,16 @@ public class CustomQueriesTests extends PersonRepositoryQueryTests {
         assertThat(repository.findUsingQuery(new Query(stringMapValuesContainString))).containsOnly(donny, boyd);
 
         int valueToSearchLessThan = 100;
-        assertThat(carter.getIntMap().get("key1")).isLessThan(valueToSearchLessThan);
         assertThat(carter.getIntMap().get(keyExactMatch)).isLessThan(valueToSearchLessThan);
 
         // it cannot be easily combined using boolean logic
-        // because in fact it is a "less than" Exp that uses the result of "MapExp.getByKey" Exp,
+        // because in fact it is a "less than" Exp that uses the result of another Exp "MapExp.getByKey",
         // so it requires new logic if exposed to users
         Qualifier intMapWithExactKeyAndValueLt100 = Qualifier.builder()
-            .setField("intMap")
+            .setField("intMap") // Map bin name
             .setFilterOperation(FilterOperation.MAP_VAL_LT_BY_KEY)
-            .setKey(Value.get("key2"))
-            .setValue(Value.get(100))
-            .setDotPath(List.of("intMap", keyExactMatch))
-            .setConverter(getMappingAerospikeConverter(new AerospikeCustomConversions(Collections.emptyList())))
+            .setKey(Value.get(keyExactMatch)) // Map key
+            .setValue(Value.get(valueToSearchLessThan)) // Map value to compare with
             .build();
         assertThat(repository.findUsingQuery(new Query(intMapWithExactKeyAndValueLt100))).containsOnly(carter);
     }


### PR DESCRIPTION
- not providing dotPath until CTX path is needed (i.e. for not nested queries)
- remove converter from the mandatory custom query parameters
- add Javadoc where needed