### PR TITLE
FMWK-445 Refactor value setters in Qualifier builders

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/annotation/Beta.java
+++ b/src/main/java/org/springframework/data/aerospike/annotation/Beta.java
@@ -1,5 +1,6 @@
 package org.springframework.data.aerospike.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -10,6 +11,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
+@Documented
 public @interface Beta {
 
 }

--- a/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/AerospikeTemplate.java
@@ -786,7 +786,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
     private BatchPolicy getBatchPolicyFilterExp(Query query) {
         if (queryCriteriaIsNotNull(query)) {
             BatchPolicy policy = new BatchPolicy(getAerospikeClient().getBatchPolicyDefault());
-            policy.filterExp = queryEngine.getFilterExpressionsBuilder().build(query);
+            Qualifier qualifier = query.getCriteriaObject();
+            policy.filterExp = queryEngine.getFilterExpressionsBuilder().build(qualifier);
             return policy;
         }
         return null;
@@ -815,7 +816,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
     private Policy getPolicyFilterExp(Query query) {
         if (queryCriteriaIsNotNull(query)) {
             Policy policy = new Policy(getAerospikeClient().getReadPolicyDefault());
-            policy.filterExp = queryEngine.getFilterExpressionsBuilder().build(query);
+            Qualifier qualifier = query.getCriteriaObject();
+            policy.filterExp = queryEngine.getFilterExpressionsBuilder().build(qualifier);
             return policy;
         }
         return null;
@@ -826,7 +828,8 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
             .expiration(expiration);
 
         if (queryCriteriaIsNotNull(query)) {
-            writePolicyBuilder.filterExp(queryEngine.getFilterExpressionsBuilder().build(query));
+            Qualifier qualifier = query.getCriteriaObject();
+            writePolicyBuilder.filterExp(queryEngine.getFilterExpressionsBuilder().build(qualifier));
         }
         WritePolicy writePolicy = writePolicyBuilder.build();
 
@@ -1424,7 +1427,6 @@ public class AerospikeTemplate extends BaseAerospikeTemplate implements Aerospik
         }
 
         KeyRecordIterator recIterator;
-
         if (targetClass != null) {
             String[] binNames = getBinNamesFromTargetClass(targetClass, mappingContext);
             recIterator = queryEngine.select(namespace, setName, binNames, query);

--- a/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
+++ b/src/main/java/org/springframework/data/aerospike/core/ReactiveAerospikeTemplate.java
@@ -875,7 +875,8 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
             Policy policy = null;
             if (queryCriteriaIsNotNull(query)) {
                 policy = new Policy(reactorClient.getReadPolicyDefault());
-                policy.filterExp = reactorQueryEngine.getFilterExpressionsBuilder().build(query);
+                Qualifier qualifier = query.getCriteriaObject();
+                policy.filterExp = reactorQueryEngine.getFilterExpressionsBuilder().build(qualifier);
             }
             return reactorClient.get(policy, key, binNames)
                 .filter(keyRecord -> Objects.nonNull(keyRecord.record))
@@ -1010,7 +1011,8 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
     private BatchPolicy getBatchPolicyFilterExp(Query query) {
         if (queryCriteriaIsNotNull(query)) {
             BatchPolicy policy = new BatchPolicy(reactorClient.getAerospikeClient().getBatchPolicyDefault());
-            policy.filterExp = reactorQueryEngine.getFilterExpressionsBuilder().build(query);
+            Qualifier qualifier = query.getCriteriaObject();
+            policy.filterExp = reactorQueryEngine.getFilterExpressionsBuilder().build(qualifier);
             return policy;
         }
         return null;
@@ -1267,7 +1269,8 @@ public class ReactiveAerospikeTemplate extends BaseAerospikeTemplate implements 
             .expiration(expiration);
 
         if (queryCriteriaIsNotNull(query)) {
-            writePolicyBuilder.filterExp(reactorQueryEngine.getFilterExpressionsBuilder().build(query));
+            Qualifier qualifier = query.getCriteriaObject();
+            writePolicyBuilder.filterExp(reactorQueryEngine.getFilterExpressionsBuilder().build(qualifier));
         }
         WritePolicy writePolicy = writePolicyBuilder.build();
 

--- a/src/main/java/org/springframework/data/aerospike/query/FilterExpressionsBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/query/FilterExpressionsBuilder.java
@@ -17,18 +17,22 @@ package org.springframework.data.aerospike.query;
 
 import com.aerospike.client.exp.Exp;
 import com.aerospike.client.exp.Expression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.aerospike.query.qualifier.Qualifier;
-import org.springframework.data.aerospike.repository.query.Query;
 
 import static org.springframework.data.aerospike.query.FilterOperation.dualFilterOperations;
-import static org.springframework.data.aerospike.query.QualifierUtils.queryCriteriaIsNotNull;
 
 public class FilterExpressionsBuilder {
 
-    public Expression build(Query query) {
-        Qualifier qualifier = queryCriteriaIsNotNull(query) ? query.getCriteriaObject() : null;
+    private static final Logger logger = LoggerFactory.getLogger(FilterExpressionsBuilder.class);
+
+    public Expression build(Qualifier qualifier) {
         if (qualifier != null && requiresFilterExp(qualifier)) {
-            return Exp.build(qualifier.getFilterExp());
+            Exp exp = qualifier.getFilterExp();
+            if (exp == null) logger.debug("FilterExp is not set");
+            logger.debug("FilterExp is set");
+            return Exp.build(exp);
         }
         return null;
     }

--- a/src/main/java/org/springframework/data/aerospike/query/ReactorQueryEngine.java
+++ b/src/main/java/org/springframework/data/aerospike/query/ReactorQueryEngine.java
@@ -108,7 +108,7 @@ public class ReactorQueryEngine {
         }
         Statement statement = statementBuilder.build(namespace, set, query, binNames);
         statement.setMaxRecords(queryMaxRecords);
-        QueryPolicy localQueryPolicy = getQueryPolicy(query, true);
+        QueryPolicy localQueryPolicy = getQueryPolicy(qualifier, true);
 
         if (!scansEnabled && statement.getFilter() == null) {
             return Flux.error(new IllegalStateException(QueryEngine.SCANS_DISABLED_MESSAGE));
@@ -128,7 +128,8 @@ public class ReactorQueryEngine {
     public Flux<KeyRecord> selectForCount(String namespace, String set, @Nullable Query query) {
         Statement statement = statementBuilder.build(namespace, set, query);
         statement.setMaxRecords(queryMaxRecords);
-        QueryPolicy localQueryPolicy = getQueryPolicy(query, false);
+        Qualifier qualifier = queryCriteriaIsNotNull(query) ? query.getCriteriaObject() : null;
+        QueryPolicy localQueryPolicy = getQueryPolicy(qualifier, false);
 
         if (!scansEnabled && statement.getFilter() == null) {
             return Flux.error(new IllegalStateException(QueryEngine.SCANS_DISABLED_MESSAGE));
@@ -137,9 +138,9 @@ public class ReactorQueryEngine {
         return client.query(localQueryPolicy, statement);
     }
 
-    private QueryPolicy getQueryPolicy(Query query, boolean includeBins) {
+    private QueryPolicy getQueryPolicy(Qualifier qualifier, boolean includeBins) {
         QueryPolicy queryPolicy = new QueryPolicy(client.getQueryPolicyDefault());
-        queryPolicy.filterExp = filterExpressionsBuilder.build(query);
+        queryPolicy.filterExp = filterExpressionsBuilder.build(qualifier);
         queryPolicy.includeBinData = includeBins;
         return queryPolicy;
     }

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/BaseQualifierBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/BaseQualifierBuilder.java
@@ -28,10 +28,37 @@ public abstract class BaseQualifierBuilder<T extends BaseQualifierBuilder<?>> im
     }
 
     /**
-     * Set FilterOperation for qualifier. Mandatory parameter.
+     * Set FilterOperation. Mandatory parameter.
      */
     public T setFilterOperation(FilterOperation operationType) {
         map.put(FILTER_OPERATION, operationType);
+        return (T) this;
+    }
+
+    /**
+     * Set value. Mandatory parameter for bin or metadata query for all operations
+     * except {@link FilterOperation#IS_NOT_NULL} and {@link FilterOperation#IS_NULL}.
+     * <p>
+     *
+     * @param value The provided object will be read into a {@link Value},
+     *              so its type must be recognizable by {@link Value#get(Object)}.
+     */
+    public T setValue(Object value) {
+        this.map.put(VALUE, Value.get(value));
+        return (T) this;
+    }
+
+    /**
+     * Set second value.
+     * <p>
+     * Use one of the Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
+     * second value into a {@link Value} object.
+     *
+     * @param secondValue The provided object will be read into a {@link Value},
+     *              so its type must be recognizable by {@link Value#get(Object)}.
+     * */
+    public T setSecondValue(Object secondValue) {
+        this.map.put(SECOND_VALUE, Value.get(secondValue));
         return (T) this;
     }
 

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/ConjunctionQualifierBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/ConjunctionQualifierBuilder.java
@@ -24,4 +24,5 @@ class ConjunctionQualifierBuilder extends BaseQualifierBuilder<ConjunctionQualif
         Assert.notEmpty(this.getQualifiers(), "Qualifiers must not be empty");
         Assert.isTrue(this.getQualifiers().length > 1, "There must be at least 2 qualifiers");
     }
+
 }

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/IdQualifierBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/IdQualifierBuilder.java
@@ -77,4 +77,5 @@ class IdQualifierBuilder extends BaseQualifierBuilder<IdQualifierBuilder> {
         this.map.put(MULTIPLE_IDS_FIELD, ids);
         return this;
     }
+
 }

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/Qualifier.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/Qualifier.java
@@ -17,6 +17,7 @@
 package org.springframework.data.aerospike.query.qualifier;
 
 import com.aerospike.client.Value;
+import com.aerospike.client.cdt.CTX;
 import com.aerospike.client.command.ParticleType;
 import com.aerospike.client.exp.Exp;
 import com.aerospike.client.query.Filter;
@@ -94,8 +95,16 @@ public class Qualifier implements CriteriaDefinition, Map<QualifierKey, Object>,
         return (String) internalMap.get(BIN_NAME);
     }
 
+    public boolean hasPath() {
+        return internalMap.containsKey(PATH);
+    }
+
     public String getPath() {
         return (String) internalMap.get(PATH);
+    }
+
+    public boolean hasMetadataField() {
+        return internalMap.containsKey(METADATA_FIELD);
     }
 
     public CriteriaDefinition.AerospikeMetadata getMetadataField() {
@@ -130,8 +139,11 @@ public class Qualifier implements CriteriaDefinition, Map<QualifierKey, Object>,
         return this.hasSingleId() ? internalMap.get(SINGLE_ID_FIELD) : internalMap.get(MULTIPLE_IDS_FIELD);
     }
 
-    public FilterOperation getFilterOperation() {
-        return (FilterOperation) internalMap.get(FILTER_OPERATION);
+    /**
+     * Set CTX[].
+     */
+    public CTX[] getCtxArray() {
+        return (CTX[]) internalMap.get(CTX_ARRAY);
     }
 
     public Qualifier[] getQualifiers() {
@@ -140,6 +152,10 @@ public class Qualifier implements CriteriaDefinition, Map<QualifierKey, Object>,
 
     public Value getKey() {
         return (Value) internalMap.get(KEY);
+    }
+
+    public boolean hasValue() {
+        return internalMap.containsKey(VALUE);
     }
 
     public Value getValue() {

--- a/src/main/java/org/springframework/data/aerospike/query/qualifier/QualifierBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/query/qualifier/QualifierBuilder.java
@@ -1,6 +1,5 @@
 package org.springframework.data.aerospike.query.qualifier;
 
-import com.aerospike.client.Value;
 import com.aerospike.client.cdt.CTX;
 import org.springframework.data.aerospike.annotation.Beta;
 import org.springframework.data.aerospike.index.AerospikeContextDslResolverUtils;
@@ -20,8 +19,6 @@ import static org.springframework.data.aerospike.index.AerospikeContextDslResolv
 import static org.springframework.data.aerospike.index.AerospikeContextDslResolverUtils.isCtxMapValue;
 import static org.springframework.data.aerospike.query.qualifier.QualifierKey.IGNORE_CASE;
 import static org.springframework.data.aerospike.query.qualifier.QualifierKey.PATH;
-import static org.springframework.data.aerospike.query.qualifier.QualifierKey.SECOND_VALUE;
-import static org.springframework.data.aerospike.query.qualifier.QualifierKey.VALUE;
 
 @Beta
 public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
@@ -102,29 +99,6 @@ public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
         return this;
     }
 
-    /**
-     * Set value. Mandatory parameter for bin query for all operations except {@link FilterOperation#IS_NOT_NULL} and
-     * {@link FilterOperation#IS_NULL}.
-     * <p>
-     * Use one of the Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
-     * value into a {@link Value} object.
-     */
-    public QualifierBuilder setValue(Value value) {
-        this.map.put(VALUE, value);
-        return this;
-    }
-
-    /**
-     * Set second value.
-     * <p>
-     * Use one of the Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
-     * second value into a {@link Value} object.
-     */
-    public QualifierBuilder setSecondValue(Value secondValue) {
-        this.map.put(SECOND_VALUE, secondValue);
-        return this;
-    }
-
     protected void validate() {
         if (!StringUtils.hasText(this.getPath())) {
             throw new IllegalArgumentException("Expecting path parameter to be provided");
@@ -142,8 +116,9 @@ public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
 
         List<FilterOperation> betweenList = List.of(FilterOperation.BETWEEN, FilterOperation.MAP_VAL_BETWEEN_BY_KEY,
             FilterOperation.MAP_VAL_BETWEEN, FilterOperation.MAP_KEYS_BETWEEN, FilterOperation.COLLECTION_VAL_BETWEEN);
-        if (betweenList.contains(this.getFilterOperation()) &&
-            (this.getValue() == null || this.getSecondValue() == null)) {
+        if (betweenList.contains(this.getFilterOperation())
+            && ((this.getValue() == null || this.getSecondValue() == null)
+                || (this.getValue().getObject() == null || this.getSecondValue().getObject() == null))) {
             throw new IllegalArgumentException(this.getFilterOperation() + ": expecting both value and secondValue " +
                 "to be provided");
         }
@@ -217,4 +192,5 @@ public class QualifierBuilder extends BaseQualifierBuilder<QualifierBuilder> {
             .filter(Objects::nonNull)
             .toArray(CTX[]::new);
     }
+
 }

--- a/src/main/java/org/springframework/data/aerospike/repository/query/AerospikeQueryCreator.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/query/AerospikeQueryCreator.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.aerospike.repository.query;
 
-import com.aerospike.client.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.aerospike.convert.MappingAerospikeConverter;
@@ -32,7 +31,6 @@ import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,7 +52,7 @@ import static org.springframework.data.aerospike.repository.query.AerospikeQuery
  */
 public class AerospikeQueryCreator extends AbstractQueryCreator<Query, CriteriaDefinition> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AerospikeQueryCreator.class);
+    private static final Logger logger = LoggerFactory.getLogger(AerospikeQueryCreator.class);
     private final AerospikeMappingContext context;
     private final MappingAerospikeConverter converter;
     private final ServerVersionSupport versionSupport;
@@ -88,11 +86,6 @@ public class AerospikeQueryCreator extends AbstractQueryCreator<Query, CriteriaD
     @Override
     protected Query complete(CriteriaDefinition criteria, Sort sort) {
         Query query = criteria == null ? null : new Query(criteria).with(sort);
-
-        if (LOG.isDebugEnabled() && criteria != null) {
-            logQualifierDetails(criteria);
-        }
-
         return query;
     }
 
@@ -200,28 +193,5 @@ public class AerospikeQueryCreator extends AbstractQueryCreator<Query, CriteriaD
         parametersIterator.forEachRemaining(param -> params.add(convertIfNecessary(param, converter)));
         // null parameters are not allowed, instead AerospikeNullQueryCriteria.NULL_PARAM should be used
         return params.stream().filter(Objects::nonNull).collect(Collectors.toList());
-    }
-
-    private void logQualifierDetails(CriteriaDefinition criteria) {
-        Qualifier qualifier = criteria.getCriteriaObject();
-        Qualifier[] qualifiers = qualifier.getQualifiers();
-        if (qualifiers != null && qualifiers.length > 0) {
-            Arrays.stream(qualifiers).forEach(this::logQualifierDetails);
-        }
-
-        String binName = (StringUtils.hasLength(qualifier.getBinName()) ? qualifier.getBinName() : "");
-        String operation = qualifier.getOperation().toString();
-        operation = (StringUtils.hasLength(operation) ? operation : "N/A");
-        String key = printValue(qualifier.getKey());
-        String value = printValue(qualifier.getValue());
-        String value2 = printValue(qualifier.getSecondValue());
-
-        LOG.debug("Created query: bin name = {}, operation = {}, key = {}, value = {}, value2 = {}",
-            binName, operation, key, value, value2);
-    }
-
-    private String printValue(Value value) {
-        if (value != null && StringUtils.hasLength(value.toString())) return value.toString();
-        return value == Value.getAsNull() ? "null" : "";
     }
 }

--- a/src/main/java/org/springframework/data/aerospike/repository/query/QueryQualifierBuilder.java
+++ b/src/main/java/org/springframework/data/aerospike/repository/query/QueryQualifierBuilder.java
@@ -86,29 +86,6 @@ public class QueryQualifierBuilder extends BaseQualifierBuilder<QualifierBuilder
     }
 
     /**
-     * Set value. Mandatory parameter for bin query for all operations except {@link FilterOperation#IS_NOT_NULL} and
-     * {@link FilterOperation#IS_NULL}.
-     * <p>
-     * Use one of the Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
-     * value into a {@link Value} object.
-     */
-    public QueryQualifierBuilder setValue(Value value) {
-        this.map.put(VALUE, value);
-        return this;
-    }
-
-    /**
-     * Set second value.
-     * <p>
-     * Use one of the Value get() methods ({@link Value#get(int)}, {@link Value#get(String)} etc.) to firstly read the
-     * second value into a {@link Value} object.
-     */
-    public QueryQualifierBuilder setSecondValue(Value secondValue) {
-        this.map.put(SECOND_VALUE, secondValue);
-        return this;
-    }
-
-    /**
      * For "find by one level nested map containing" queries. Set the type of the nested map value using
      * {@link ParticleType}.
      */
@@ -128,4 +105,5 @@ public class QueryQualifierBuilder extends BaseQualifierBuilder<QualifierBuilder
     public boolean hasDotPath() {
         return map.get(DOT_PATH) != null;
     }
+
 }

--- a/src/test/java/org/springframework/data/aerospike/BaseBlockingIntegrationTests.java
+++ b/src/test/java/org/springframework/data/aerospike/BaseBlockingIntegrationTests.java
@@ -77,7 +77,7 @@ public abstract class BaseBlockingIntegrationTests extends BaseIntegrationTests 
         Qualifier lastUpdateTimeLtMillis = Qualifier.metadataBuilder()
             .setMetadataField(LAST_UPDATE_TIME)
             .setFilterOperation(operation)
-            .setValueAsObj(lastUpdateTimeMillis * MILLIS_TO_NANO)
+            .setValue(lastUpdateTimeMillis * MILLIS_TO_NANO)
             .build();
         return template.find(new Query(lastUpdateTimeLtMillis), entityClass).toList();
     }

--- a/src/test/java/org/springframework/data/aerospike/BaseReactiveIntegrationTests.java
+++ b/src/test/java/org/springframework/data/aerospike/BaseReactiveIntegrationTests.java
@@ -84,7 +84,7 @@ public abstract class BaseReactiveIntegrationTests extends BaseIntegrationTests 
         Qualifier lastUpdateTimeLtMillis = Qualifier.metadataBuilder()
             .setMetadataField(LAST_UPDATE_TIME)
             .setFilterOperation(operation)
-            .setValueAsObj(lastUpdateTimeMillis * MILLIS_TO_NANO)
+            .setValue(lastUpdateTimeMillis * MILLIS_TO_NANO)
             .build();
         return reactiveTemplate.find(new Query(lastUpdateTimeLtMillis), entityClass).collectList().block();
     }

--- a/src/test/java/org/springframework/data/aerospike/query/QualifierTests.java
+++ b/src/test/java/org/springframework/data/aerospike/query/QualifierTests.java
@@ -195,7 +195,7 @@ class QualifierTests extends BaseQueryEngineTests {
         Qualifier qualifier = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.GT)
-            .setValueAsObj(1L)
+            .setValue(1L)
             .build();
 
         KeyRecordIterator iterator = queryEngine.select(namespace, SET_NAME, null, new Query(qualifier));

--- a/src/test/java/org/springframework/data/aerospike/repository/query/blocking/noindex/findBy/CustomQueriesTests.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/query/blocking/noindex/findBy/CustomQueriesTests.java
@@ -23,7 +23,7 @@ public class CustomQueriesTests extends PersonRepositoryQueryTests {
         Qualifier sinceUpdateTimeLt50Seconds = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.LT)
-            .setValueAsObj(50000L)
+            .setValue(50000L)
             .build();
         assertThat(repository.findUsingQuery(new Query(sinceUpdateTimeLt50Seconds))).containsAll(allPersons);
 
@@ -31,8 +31,8 @@ public class CustomQueriesTests extends PersonRepositoryQueryTests {
         Qualifier sinceUpdateTimeBetween1And50000 = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.BETWEEN)
-            .setValueAsObj(1L)
-            .setSecondValueAsObj(50000L)
+            .setValue(1L)
+            .setSecondValue(50000L)
             .build();
         assertThat(repository.findUsingQuery(new Query(sinceUpdateTimeBetween1And50000)))
             .containsAll(repository.findUsingQuery(new Query(sinceUpdateTimeLt50Seconds)));
@@ -71,14 +71,14 @@ public class CustomQueriesTests extends PersonRepositoryQueryTests {
         Qualifier sinceUpdateTimeGt1 = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.GT)
-            .setValueAsObj(1L)
+            .setValue(1L)
             .build();
 
         // creating an expression "since_update_time metadata value is less than 50 seconds"
         Qualifier sinceUpdateTimeLt50Seconds = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.LT)
-            .setValueAsObj(50000L)
+            .setValue(50000L)
             .build();
         assertThat(repository.findUsingQuery(new Query(sinceUpdateTimeLt50Seconds))).containsAll(allPersons);
 
@@ -86,8 +86,8 @@ public class CustomQueriesTests extends PersonRepositoryQueryTests {
         Qualifier sinceUpdateTimeBetween1And50000 = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.BETWEEN)
-            .setValueAsObj(1L)
-            .setSecondValueAsObj(50000L)
+            .setValue(1L)
+            .setSecondValue(50000L)
             .build();
         assertThat(repository.findUsingQuery(new Query(sinceUpdateTimeBetween1And50000))).containsAll(allPersons);
 
@@ -202,48 +202,57 @@ public class CustomQueriesTests extends PersonRepositoryQueryTests {
         assertThatThrownBy(() -> repository.findUsingQuery(new Query(Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.BETWEEN)
-            .setValueAsObj(1L)
+            .setValue(1L)
             .build())))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("BETWEEN: value2 is expected to be set as Long");
+            .hasMessage("BETWEEN: expecting secondValue to be provided");
 
         assertThatThrownBy(() -> repository.findUsingQuery(new Query(Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.BETWEEN)
-            .setValueAsObj("value")
-            .setSecondValueAsObj(1L)
+            .setValue(1L)
+            .setSecondValue(null)
             .build())))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("BETWEEN: value1 is expected to be set as Long");
+            .hasMessage("BETWEEN: secondValue is expected to be set as Long");
+
+        assertThatThrownBy(() -> repository.findUsingQuery(new Query(Qualifier.metadataBuilder()
+            .setMetadataField(SINCE_UPDATE_TIME)
+            .setFilterOperation(FilterOperation.BETWEEN)
+            .setValue("value")
+            .setSecondValue(1L)
+            .build())))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("BETWEEN: value is expected to be set as Long");
 
         assertThatThrownBy(() -> repository.findUsingQuery(new Query(Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.GT)
-            .setValueAsObj(1)
+            .setValue(1)
             .build())))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("GT: value1 is expected to be set as Long");
+            .hasMessage("GT: value is expected to be set as Long");
 
         assertThatThrownBy(() -> repository.findUsingQuery(new Query(Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.LT)
-            .setValueAsObj(1)
+            .setValue(1)
             .build())))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("LT: value1 is expected to be set as Long");
+            .hasMessage("LT: value is expected to be set as Long");
 
         assertThatThrownBy(() -> repository.findUsingQuery(new Query(Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.LTEQ)
-            .setValueAsObj(1)
+            .setValue(1)
             .build())))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("LTEQ: value1 is expected to be set as Long");
+            .hasMessage("LTEQ: value is expected to be set as Long");
 
         assertThatThrownBy(() -> repository.findUsingQuery(new Query(Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.STARTS_WITH)
-            .setValueAsObj(1L)
+            .setValue(1L)
             .build())))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Operation STARTS_WITH cannot be applied to metadataField");

--- a/src/test/java/org/springframework/data/aerospike/repository/query/reactive/indexed/findBy/CustomQueriesTests.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/query/reactive/indexed/findBy/CustomQueriesTests.java
@@ -24,7 +24,7 @@ public class CustomQueriesTests extends ReactiveIndexedPersonRepositoryQueryTest
         Qualifier sinceUpdateTimeLt50Seconds = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.LT)
-            .setValueAsObj(50000L)
+            .setValue(50000L)
             .build();
         assertThat(reactiveRepository.findUsingQuery(new Query(sinceUpdateTimeLt50Seconds)).collectList().block())
             .containsAll(allIndexedPersons);
@@ -33,8 +33,8 @@ public class CustomQueriesTests extends ReactiveIndexedPersonRepositoryQueryTest
         Qualifier sinceUpdateTimeBetween1And50000 = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.BETWEEN)
-            .setValueAsObj(1L)
-            .setSecondValueAsObj(50000L)
+            .setValue(1L)
+            .setSecondValue(50000L)
             .build();
         assertThat(reactiveRepository.findUsingQuery(new Query(sinceUpdateTimeBetween1And50000)).collectList().block())
             .containsAll(reactiveRepository.findUsingQuery(new Query(sinceUpdateTimeLt50Seconds)).collectList()
@@ -50,14 +50,14 @@ public class CustomQueriesTests extends ReactiveIndexedPersonRepositoryQueryTest
         Qualifier sinceUpdateTimeGt1 = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.GT)
-            .setValueAsObj(1L)
+            .setValue(1L)
             .build();
 
         // creating an expression "since_update_time metadata value is less than 50 seconds"
         Qualifier sinceUpdateTimeLt50Seconds = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.LT)
-            .setValueAsObj(50000L)
+            .setValue(50000L)
             .build();
         assertThat(reactiveRepository.findUsingQuery(new Query(sinceUpdateTimeLt50Seconds)).collectList().block())
             .containsAll(allIndexedPersons);
@@ -66,8 +66,8 @@ public class CustomQueriesTests extends ReactiveIndexedPersonRepositoryQueryTest
         Qualifier sinceUpdateTimeBetween1And50000 = Qualifier.metadataBuilder()
             .setMetadataField(SINCE_UPDATE_TIME)
             .setFilterOperation(FilterOperation.BETWEEN)
-            .setValueAsObj(1L)
-            .setSecondValueAsObj(50000L)
+            .setValue(1L)
+            .setSecondValue(50000L)
             .build();
 
         // creating an expression "firsName is equal to Petra"


### PR DESCRIPTION
* Make setValue() and setSecondValue() accept Object
* Replace setValueAsObj() and setSecondValueAsObj() in MetadataQualifierBuilder with unified setValue() and setSecondValue()
* Add logging whether sIndex filter and filterExp are created
* cleanup