### PR TITLE
FMWK-451 Find by "not equals" doesn't return entities with nonexistent path

### DIFF
--- a/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
@@ -65,7 +65,8 @@ public abstract class AbstractAerospikeDataConfiguration extends AerospikeDataCo
         log.debug("AerospikeDataSettings.queryMaxRecords: {}", queryMaxRecords);
         queryEngine.setQueryMaxRecords(queryMaxRecords);
         if (!settings.getDataSettings().isWriteSortedMaps()) {
-            log.debug("AerospikeDataSettings.writeSortedMaps: false");
+            log.debug("AerospikeDataSettings.writeSortedMaps is set to false, " +
+                "Maps and POJOs will be written as unsorted Maps (decrease in performance compared with sorted Maps)");
         }
         return queryEngine;
     }

--- a/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
@@ -66,7 +66,8 @@ public abstract class AbstractAerospikeDataConfiguration extends AerospikeDataCo
         queryEngine.setQueryMaxRecords(queryMaxRecords);
         if (!settings.getDataSettings().isWriteSortedMaps()) {
             log.info("AerospikeDataSettings.writeSortedMaps is set to false, " +
-                "Maps and POJOs will be written as unsorted Maps (decrease in performance compared with sorted Maps)");
+                "Maps and POJOs will be written as unsorted Maps (degrades performance of Map-related operations ," +
+                " does not allow comparing Maps)");
         }
         return queryEngine;
     }

--- a/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
@@ -65,7 +65,7 @@ public abstract class AbstractAerospikeDataConfiguration extends AerospikeDataCo
         log.debug("AerospikeDataSettings.queryMaxRecords: {}", queryMaxRecords);
         queryEngine.setQueryMaxRecords(queryMaxRecords);
         if (!settings.getDataSettings().isWriteSortedMaps()) {
-            log.debug("AerospikeDataSettings.writeSortedMaps is set to false, " +
+            log.info("AerospikeDataSettings.writeSortedMaps is set to false, " +
                 "Maps and POJOs will be written as unsorted Maps (decrease in performance compared with sorted Maps)");
         }
         return queryEngine;

--- a/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
+++ b/src/main/java/org/springframework/data/aerospike/config/AbstractAerospikeDataConfiguration.java
@@ -64,6 +64,9 @@ public abstract class AbstractAerospikeDataConfiguration extends AerospikeDataCo
         long queryMaxRecords = settings.getDataSettings().getQueryMaxRecords();
         log.debug("AerospikeDataSettings.queryMaxRecords: {}", queryMaxRecords);
         queryEngine.setQueryMaxRecords(queryMaxRecords);
+        if (!settings.getDataSettings().isWriteSortedMaps()) {
+            log.debug("AerospikeDataSettings.writeSortedMaps: false");
+        }
         return queryEngine;
     }
 

--- a/src/main/java/org/springframework/data/aerospike/query/FilterOperation.java
+++ b/src/main/java/org/springframework/data/aerospike/query/FilterOperation.java
@@ -244,7 +244,6 @@ public enum FilterOperation {
                         value.getClass().getSimpleName());
                 };
                 return Exp.or(Exp.not(Exp.binExists(getBinName(qualifierMap))), ne);
-
             });
         }
 

--- a/src/main/java/org/springframework/data/aerospike/query/FilterOperation.java
+++ b/src/main/java/org/springframework/data/aerospike/query/FilterOperation.java
@@ -223,27 +223,19 @@ public enum FilterOperation {
         public Exp filterExp(Map<QualifierKey, Object> qualifierMap) {
             return getMetadataExp(qualifierMap).orElseGet(() -> {
                 Value value = getValue(qualifierMap);
-                return switch (value.getType()) {
+                Exp ne = switch (value.getType()) {
                     // FMWK-175: Exp.ne() does not return null bins, so Exp.not(Exp.binExists()) is added
-                    case INTEGER -> {
-                        Exp ne = Exp.ne(Exp.intBin(getBinName(qualifierMap)), Exp.val(value.toLong()));
-                        yield Exp.or(Exp.not(Exp.binExists(getBinName(qualifierMap))), ne);
-                    }
+                    case INTEGER -> Exp.ne(Exp.intBin(getBinName(qualifierMap)), Exp.val(value.toLong()));
                     case STRING -> {
                         if (ignoreCase(qualifierMap)) {
                             String equalsRegexp = getStringEquals(value.toString());
-                            Exp regexCompare = Exp.not(Exp.regexCompare(equalsRegexp, RegexFlag.ICASE,
+                            yield Exp.not(Exp.regexCompare(equalsRegexp, RegexFlag.ICASE,
                                 Exp.stringBin(getBinName(qualifierMap))));
-                            yield Exp.or(Exp.not(Exp.binExists(getBinName(qualifierMap))), regexCompare);
                         } else {
-                            Exp ne = Exp.ne(Exp.stringBin(getBinName(qualifierMap)), Exp.val(value.toString()));
-                            yield Exp.or(Exp.not(Exp.binExists(getBinName(qualifierMap))), ne);
+                            yield Exp.ne(Exp.stringBin(getBinName(qualifierMap)), Exp.val(value.toString()));
                         }
                     }
-                    case BOOL -> {
-                        Exp ne = Exp.ne(Exp.boolBin(getBinName(qualifierMap)), Exp.val((Boolean) value.getObject()));
-                        yield Exp.or(Exp.not(Exp.binExists(getBinName(qualifierMap))), ne);
-                    }
+                    case BOOL -> Exp.ne(Exp.boolBin(getBinName(qualifierMap)), Exp.val((Boolean) value.getObject()));
                     case MAP -> getFilterExp(Exp.val((Map<?, ?>) value.getObject()), getBinName(qualifierMap), Exp::ne,
                         Exp::mapBin);
                     case LIST -> getFilterExp(Exp.val((List<?>) value.getObject()), getBinName(qualifierMap), Exp::ne,
@@ -251,6 +243,8 @@ public enum FilterOperation {
                     default -> throw new IllegalArgumentException("NOTEQ FilterExpression unsupported particle type: " +
                         value.getClass().getSimpleName());
                 };
+                return Exp.or(Exp.not(Exp.binExists(getBinName(qualifierMap))), ne);
+
             });
         }
 
@@ -550,7 +544,8 @@ public enum FilterOperation {
     MAP_VAL_NOTEQ_BY_KEY {
         @Override
         public Exp filterExp(Map<QualifierKey, Object> qualifierMap) {
-            return getFilterExpMapValNotEqOrFail(qualifierMap, Exp::ne);
+            Exp binIsNull = Exp.not(Exp.binExists(getBinName(qualifierMap)));
+            return Exp.or(binIsNull, getFilterExpMapValNotEqOrFail(qualifierMap, Exp::ne));
         }
 
         @Override

--- a/src/test/java/org/springframework/data/aerospike/repository/query/blocking/noindex/findBy/NotEqualTests.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/query/blocking/noindex/findBy/NotEqualTests.java
@@ -37,22 +37,17 @@ public class NotEqualTests extends PersonRepositoryQueryTests {
 
     @Test
     void findByNestedSimplePropertyNotEqual() {
-        String zipCode = "C0123456789";
-        assertThat(carter.getAddress().getZipCode()).isNotEqualTo(zipCode);
-        assertThat(repository.findByAddressZipCodeIsNot(zipCode)).contains(carter);
-
         oliver.setFriend(alicia);
         repository.save(oliver);
         dave.setFriend(oliver);
         repository.save(dave);
         carter.setFriend(dave);
         repository.save(carter);
+        assertThat(carter.getFriend().getAge()).isEqualTo(42);
 
+        // find all records where friend's age is not 42 and all without friend.age
         List<Person> result = repository.findByFriendAgeIsNot(42);
-
-        assertThat(result)
-            .hasSize(2)
-            .containsExactlyInAnyOrder(dave, oliver);
+        assertThat(result).doesNotContain(carter);
 
         TestUtils.setFriendsToNull(repository, oliver, dave, carter);
     }

--- a/src/test/java/org/springframework/data/aerospike/repository/query/blocking/noindex/findBy/NotInTests.java
+++ b/src/test/java/org/springframework/data/aerospike/repository/query/blocking/noindex/findBy/NotInTests.java
@@ -32,7 +32,8 @@ public class NotInTests extends PersonRepositoryQueryTests {
     void findByNestedSimplePropertyNotIn_String() {
         assertThat(carter.getAddress().getZipCode()).isEqualTo("C0124");
         assertThat(dave.getAddress().getZipCode()).isEqualTo("C0123");
-        assertThat(repository.findByAddressZipCodeNotIn(List.of("C0123", "C0125"))).containsOnly(carter);
+        // find all records where address' zipCode is not C0123 or C0125, and all without address.zipCode
+        assertThat(repository.findByAddressZipCodeNotIn(List.of("C0123", "C0125"))).doesNotContain(dave);
     }
 
     @Test


### PR DESCRIPTION
* Support returning entities with nonexistent path for NOTEQ