### PR TITLE
FMWK-638 add explicit mockito-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,6 +435,8 @@
                     </includes>
                     <excludedGroups>${excludedGroups}</excludedGroups>
                     <argLine>
+                        <!--suppress UnresolvedMavenProperty -->
+                        <!-- Property is generated at build-time by maven-dependency-plugin -->
                         -javaagent:${org.mockito:mockito-core:jar}
                         --add-opens java.base/java.util=ALL-UNNAMED
                         --add-opens java.base/java.net=ALL-UNNAMED


### PR DESCRIPTION
This is to suppress this and make it future proof : 

~~~
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (/Users/gmishra/.m2/repository/net/bytebuddy/byte-buddy-agent/1.15.11/byte-buddy-agent-1.15.11.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
~~~
