### PR TITLE
fix: update test assertions

### DIFF
--- a/src/test/java/org/springframework/data/aerospike/query/blocking/IndexedQualifierTests.java
+++ b/src/test/java/org/springframework/data/aerospike/query/blocking/IndexedQualifierTests.java
@@ -336,7 +336,7 @@ class IndexedQualifierTests extends BaseQueryEngineTests {
 
         assertThatThrownBy(() -> new Query(Qualifier.and(colorEqGreen, ageBetween28And29)))
             .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("Cannot combine DSL expression qualifiers with custom AND query, " +
+            .hasMessageContaining("Cannot combine DSL expression qualifiers in a custom logical query, " +
                 "please incorporate all conditions into one comprehensive DSL expression or combine non-DSL " +
                 "qualifiers");
 
@@ -347,7 +347,7 @@ class IndexedQualifierTests extends BaseQueryEngineTests {
 
         assertThatThrownBy(() -> new Query(Qualifier.and(colorEqGreen, colorEqGreen, ageBetween28And29_DslExpr)))
             .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("Cannot combine DSL expression qualifiers with custom AND query, " +
+            .hasMessageContaining("Cannot combine DSL expression qualifiers in a custom logical query, " +
                 "please incorporate all conditions into one comprehensive DSL expression or combine non-DSL " +
                 "qualifiers");
     }


### PR DESCRIPTION
Build failure: https://github.com/aerospike/spring-data-aerospike/actions/runs/19448882722

Relevant logs:

```
Error:  Failures: 
Error:    IndexedQualifierTests.selectOnIndexedAndQualifier_withOneIndex_usingDslExpression:339 
Expecting throwable message:
  "Cannot combine DSL expression qualifiers in a custom logical query, please incorporate all conditions into one comprehensive DSL expression or combine non-DSL qualifiers"
to contain:
  "Cannot combine DSL expression qualifiers with custom AND query, please incorporate all conditions into one comprehensive DSL expression or combine non-DSL qualifiers"
but did not.
```